### PR TITLE
fix: vision support in OpenAI and Azure OpenAI providers (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-02-19
+
+### Fixed
+- **OpenAI vision**: `OpenAIProvider::convert_messages()` now correctly handles the
+  `ChatMessage.images` field. User messages with images are serialized as multipart
+  `content` arrays (`[{type: "text", ...}, {type: "image_url", ...}]`) instead of
+  silently dropping image data. Fixes [#3](https://github.com/raphaelmansuy/edgequake-llm/issues/3).
+- **Azure OpenAI vision**: `AzureOpenAIProvider::convert_messages()` similarly updated
+  to produce multipart `content` arrays for messages with images, enabling vision
+  requests against Azure-hosted models.
+
+### Added
+- Unit tests covering multimodal message conversion in both `OpenAIProvider` and
+  `AzureOpenAIProvider` (detail levels, data URI encoding, array/string content selection).
+
 ### Documentation
 - Add provider-families.md: Deep comparison of OpenAI vs Anthropic vs Gemini API patterns
 - Add performance-tuning.md: Latency, throughput, cost optimization strategies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgequake-llm"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
- OpenAIProvider::convert_messages() now checks msg.has_images() and builds multipart ChatCompletionRequestUserMessageContent::Array when images are present, instead of silently dropping image data.
- AzureOpenAIProvider::convert_messages() updated: AzureMessage.content changed from String to serde_json::Value to support both plain text and multipart image arrays per the Azure OpenAI REST spec.
- Parse ImageData.detail ('low'/'high'/'auto') into async-openai ImageDetail enum for proper vision quality control.
- Added 15+ unit tests covering multimodal conversion in both providers.
- Added e2e test: test_openai_provider_vision_chat sends a 10x10 red PNG to gpt-4o and verifies a non-empty, image-contextual response.
- Bump version 0.2.1 → 0.2.2.