### PR TITLE
docs: add edgequake-litellm Python package docs + bump crate to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### edgequake-litellm (Python package — py-v0.1.0)
+## [0.2.4] - 2026-02-20
+
+### edgequake-llm (Rust crate)
+
+#### Documentation
+- README: added Python package section, PyPI badge, drop-in migration guide, compatibility table, and streaming/embedding examples
+- README: added `edgequake-litellm` to features list and quick-nav callout at top
+
+### edgequake-litellm (Python package — `py-v0.1.0`, PyPI)
 
 #### Added
-- **`edgequake-litellm` Python package** — drop-in LiteLLM replacement backed by Rust
-  - Import as `import edgequake_litellm as litellm` — same API as litellm
-  - `ModelResponseCompat`: wraps PyO3 `ModelResponse` with `resp.choices[0].message.content` path, dict-style access, `.id`, `.created`, `.object`, `.response_ms`, `.to_dict()`, `.finish_reason`
-  - `StreamChunkCompat`: wraps `StreamChunk` with `.choices[0].delta.content` path
-  - `EmbeddingResponseCompat`: wraps embedding results with `.data[0].embedding` path + backwards-compatible list iteration/indexing
-  - `stream_chunk_builder(chunks)` — reconstruct `ModelResponseCompat` from streaming chunks
-  - `acompletion(stream=True)` returns `AsyncGenerator[StreamChunkCompat, None]`
-  - `completion()` / `acompletion()` / `embedding()` accept `max_completion_tokens`, `seed`, `user`, `timeout`, `api_base`, `base_url`, `api_key` params for litellm compatibility
-  - `response_format` accepts `dict` (e.g., `{"type": "json_object"}`) in addition to `str`
-  - Module-level globals: `set_verbose`, `drop_params`, `NotFoundError` (alias for `ModelNotFoundError`)
-  - Multi-arch PyPI wheels: Linux (manylinux + musllinux) x86_64/aarch64, macOS x86_64/arm64, Windows x86_64/aarch64
-  - Full CI: version-check → clippy → ruff → mypy → test (8 platform+Python combos) → Linux ARM64 cross-build
-  - Publish workflow: `py-v*` tag triggers PyPI publish via OIDC trusted publishing
-- **`litellm_study/` documents** — full LiteLLM compatibility audit and DX improvement roadmap
-- **Removed `litellm-edge/`** — early prototype merged into `edgequake-litellm`
+- **`edgequake-litellm` 0.1.0** — drop-in LiteLLM replacement backed by Rust, published to [PyPI](https://pypi.org/project/edgequake-litellm/)
+  - `pip install edgequake-litellm` — pre-built wheels for 7 platform/arch combos
+  - Import as `import edgequake_litellm as litellm` — identical API to LiteLLM
+  - `completion()` / `acompletion()` — sync and async chat completions
+  - `embedding()` — text embeddings
+  - Streaming via `acompletion(stream=True)` → `AsyncGenerator[StreamChunkCompat, None]`
+  - `stream_chunk_builder(chunks)` — reconstruct full response from stream
+  - `ModelResponseCompat`: `resp.choices[0].message.content`, `.id`, `.created`, `.object`, `.response_ms`, `.to_dict()`, `.finish_reason`, dict-style access
+  - `StreamChunkCompat`: `.choices[0].delta.content`
+  - `EmbeddingResponseCompat`: `.data[0].embedding`, list iteration/indexing
+  - Extra params: `max_completion_tokens`, `seed`, `user`, `timeout`, `api_base`, `base_url`, `api_key`
+  - `response_format` accepts `dict` (`{"type": "json_object"}`) in addition to `str`
+  - Module globals: `set_verbose`, `drop_params`, `NotFoundError` (alias of `ModelNotFoundError`)
+  - Wheels: Linux manylinux/musllinux × x86\_64/aarch64, macOS x86\_64/arm64, Windows x86\_64, sdist
+  - CI: preflight → 7 platform builds → smoke tests (ubuntu/macos/windows) → PyPI publish via API token (`PYPI_API_TOKEN` secret)
+  - Publish trigger: `py-v*` git tag on `python-publish.yml`
+- **`litellm_study/` research documents** — LiteLLM compatibility audit and DX improvement roadmap
 
 ## [0.2.3] - 2026-07-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "edgequake-llm"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 [![Crates.io](https://img.shields.io/crates/v/edgequake-llm.svg)](https://crates.io/crates/edgequake-llm)
 [![Documentation](https://docs.rs/edgequake-llm/badge.svg)](https://docs.rs/edgequake-llm)
+[![PyPI](https://img.shields.io/pypi/v/edgequake-litellm.svg)](https://pypi.org/project/edgequake-litellm/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE-APACHE)
 [![CI](https://github.com/raphaelmansuy/edgequake-llm/workflows/CI/badge.svg)](https://github.com/raphaelmansuy/edgequake-llm/actions)
 
 A unified Rust library providing LLM and embedding provider abstraction with support for multiple backends, intelligent caching, rate limiting, and cost tracking.
+
+> **Python users**: see [`edgequake-litellm`](#python-package-edgequake-litellm) — a drop-in LiteLLM replacement backed by this Rust library.
 
 ## Features
 
@@ -17,6 +20,7 @@ A unified Rust library providing LLM and embedding provider abstraction with sup
 - 🎯 **Reranking**: BM25, RRF, and hybrid reranking strategies
 - 📊 **Observability**: OpenTelemetry integration for metrics and tracing
 - 🧪 **Testing**: Mock provider for unit tests
+- 🐍 **Python bindings**: `edgequake-litellm` — LiteLLM-compatible Python package
 
 ## Quick Start
 
@@ -250,6 +254,106 @@ let results = reranker.rerank(query, documents, top_k).await?;
 - [Testing](docs/testing.md) - Testing strategies and mock provider
 - [Migration Guide](docs/migration-guide.md) - Upgrading between versions
 - [FAQ](docs/faq.md) - Frequently asked questions and troubleshooting
+
+---
+
+## Python Package: edgequake-litellm
+
+`edgequake-litellm` is a drop-in replacement for [LiteLLM](https://github.com/BerriAI/litellm) backed by this Rust library. It exposes the same Python API as LiteLLM so existing code can migrate with a one-line import change.
+
+[![PyPI](https://img.shields.io/pypi/v/edgequake-litellm.svg)](https://pypi.org/project/edgequake-litellm/)
+[![Python](https://img.shields.io/pypi/pyversions/edgequake-litellm.svg)](https://pypi.org/project/edgequake-litellm/)
+
+### Install
+
+```bash
+pip install edgequake-litellm
+```
+
+Pre-built wheels ship for:
+
+| Platform | Architectures |
+|----------|---------------|
+| Linux (glibc) | x86\_64, aarch64 |
+| Linux (musl / Alpine) | x86\_64, aarch64 |
+| macOS | x86\_64, arm64 (Apple Silicon) |
+| Windows | x86\_64 |
+
+### Drop-in migration
+
+```python
+# Before
+import litellm
+
+# After — one line change
+import edgequake_litellm as litellm
+
+# All calls stay identical
+response = litellm.completion(
+    model="openai/gpt-4o",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+### Async & streaming
+
+```python
+import asyncio
+import edgequake_litellm as litellm
+
+async def main():
+    # Async completion
+    response = await litellm.acompletion(
+        model="anthropic/claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "Explain Rust in one sentence."}],
+    )
+    print(response.choices[0].message.content)
+
+    # Streaming
+    stream = await litellm.acompletion(
+        model="openai/gpt-4o",
+        messages=[{"role": "user", "content": "Count to 5"}],
+        stream=True,
+    )
+    async for chunk in stream:
+        print(chunk.choices[0].delta.content or "", end="", flush=True)
+
+asyncio.run(main())
+```
+
+### Embeddings
+
+```python
+import edgequake_litellm as litellm
+
+response = litellm.embedding(
+    model="openai/text-embedding-3-small",
+    input=["Hello world", "Rust is fast"],
+)
+vector = response.data[0].embedding
+print(f"Embedding dim: {len(vector)}")
+```
+
+### Compatibility surface
+
+| LiteLLM feature | edgequake-litellm |
+|-----------------|-------------------|
+| `completion()` / `acompletion()` | ✅ |
+| `embedding()` | ✅ |
+| Streaming (`stream=True`) | ✅ |
+| `response.choices[0].message.content` | ✅ |
+| `response.to_dict()` | ✅ |
+| `stream_chunk_builder(chunks)` | ✅ |
+| `AuthenticationError`, `RateLimitError`, `NotFoundError` | ✅ |
+| `set_verbose`, `drop_params` globals | ✅ |
+| `max_completion_tokens`, `seed`, `user`, `timeout` params | ✅ |
+
+### Source
+
+The Python package lives in [`edgequake-litellm/`](edgequake-litellm/) and is published to [PyPI](https://pypi.org/project/edgequake-litellm/) via the [python-publish workflow](.github/workflows/python-publish.yml).
+
+---
 
 ## Contributing
 


### PR DESCRIPTION
Add full docs for edgequake-litellm Python package (published to PyPI) and bump crate to 0.2.4. README: PyPI badge, install/usage/compat section. CHANGELOG: promote Unreleased to [0.2.4].