### PR TITLE
Propagate streaming usage metadata to terminal chunks

### DIFF
--- a/edgequake-litellm/src/completion.rs
+++ b/edgequake-litellm/src/completion.rs
@@ -13,7 +13,7 @@ use pyo3::types::PyList;
 use edgequake_llm::error::LlmError;
 use edgequake_llm::factory::{ProviderFactory, ProviderType};
 use edgequake_llm::traits::{
-    ChatMessage, CompletionOptions, StreamChunk, ToolChoice, ToolDefinition,
+    ChatMessage, CompletionOptions, StreamChunk, StreamUsage, ToolChoice, ToolDefinition,
 };
 
 use futures::StreamExt;
@@ -234,11 +234,19 @@ pub fn stream_completion<'py>(
                     .finish_reason
                     .clone()
                     .unwrap_or_else(|| "stop".to_string());
+                let mut usage = StreamUsage::new(resp.prompt_tokens, resp.completion_tokens);
+                if let Some(cache_hit_tokens) = resp.cache_hit_tokens {
+                    usage = usage.with_cache_hit_tokens(cache_hit_tokens);
+                }
+                if let Some(thinking_tokens) = resp.thinking_tokens {
+                    usage = usage.with_thinking_tokens(thinking_tokens);
+                }
                 vec![
                     Ok(StreamChunk::Content(resp.content)),
                     Ok(StreamChunk::Finished {
                         reason,
                         ttft_ms: None,
+                        usage: Some(usage),
                     }),
                 ]
             }

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -37,7 +37,7 @@ use tracing::{debug, instrument, warn};
 use crate::error::{LlmError, Result};
 use crate::traits::{
     ChatMessage, ChatRole, CompletionOptions, FunctionCall, LLMProvider, LLMResponse, StreamChunk,
-    ToolCall, ToolChoice, ToolDefinition,
+    StreamUsage, ToolCall, ToolChoice, ToolDefinition,
 };
 
 /// Anthropic API base URL
@@ -1091,6 +1091,9 @@ impl LLMProvider for AnthropicProvider {
         // captured in the FnMut closure state rather than recomputed from the
         // current chunk's local vec.
         let mut finished_emitted = false;
+        let mut prompt_tokens = 0usize;
+        let mut cache_hit_tokens = None;
+        let mut latest_output_tokens = 0usize;
 
         let stream = response
             .bytes_stream()
@@ -1114,6 +1117,12 @@ impl LLMProvider for AnthropicProvider {
                     if let Some(data) = line.strip_prefix("data: ") {
                         if let Ok(event) = serde_json::from_str::<StreamEvent>(data) {
                             match event {
+                                StreamEvent::MessageStart { message } => {
+                                    prompt_tokens = message.usage.input_tokens as usize;
+                                    cache_hit_tokens =
+                                        message.usage.cache_read_input_tokens.map(|t| t as usize);
+                                    latest_output_tokens = message.usage.output_tokens as usize;
+                                }
                                 StreamEvent::ContentBlockStart {
                                     index,
                                     content_block,
@@ -1168,16 +1177,27 @@ impl LLMProvider for AnthropicProvider {
                                 StreamEvent::ContentBlockStop { .. } => {
                                     // Block closed — consumer accumulates via deltas above
                                 }
-                                StreamEvent::MessageDelta { delta, .. } => {
+                                StreamEvent::MessageDelta { delta, usage } => {
+                                    if let Some(usage) = usage {
+                                        latest_output_tokens = usage.output_tokens as usize;
+                                    }
                                     // Emit Finished with the authoritative stop_reason from
                                     // message_delta.  Do NOT also emit from MessageStop to
                                     // avoid duplicate Finished chunks.
                                     if let Some(reason) = delta.stop_reason {
                                         if !finished_emitted {
                                             finished_emitted = true;
+                                            let mut usage = StreamUsage::new(
+                                                prompt_tokens,
+                                                latest_output_tokens,
+                                            );
+                                            if let Some(tokens) = cache_hit_tokens {
+                                                usage = usage.with_cache_hit_tokens(tokens);
+                                            }
                                             chunks.push(StreamChunk::Finished {
                                                 reason,
                                                 ttft_ms: None,
+                                                usage: Some(usage),
                                             });
                                         }
                                     }
@@ -1188,9 +1208,15 @@ impl LLMProvider for AnthropicProvider {
                                     // did not carry a stop_reason (error recovery path).
                                     if !finished_emitted {
                                         finished_emitted = true;
+                                        let mut usage =
+                                            StreamUsage::new(prompt_tokens, latest_output_tokens);
+                                        if let Some(tokens) = cache_hit_tokens {
+                                            usage = usage.with_cache_hit_tokens(tokens);
+                                        }
                                         chunks.push(StreamChunk::Finished {
                                             reason: "stop".to_string(),
                                             ttft_ms: None,
+                                            usage: Some(usage),
                                         });
                                     }
                                 }

--- a/src/providers/azure_openai.rs
+++ b/src/providers/azure_openai.rs
@@ -42,9 +42,9 @@ use async_openai::{
         ChatCompletionRequestMessageContentPartText, ChatCompletionRequestSystemMessageArgs,
         ChatCompletionRequestToolMessageArgs, ChatCompletionRequestUserMessageArgs,
         ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
-        ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionTools, CompletionUsage,
-        CreateChatCompletionRequestArgs, FinishReason, FunctionCall, FunctionName,
-        FunctionObjectArgs, ImageDetail, ImageUrl, ToolChoiceOptions,
+        ChatCompletionStreamOptions, ChatCompletionTool, ChatCompletionToolChoiceOption,
+        ChatCompletionTools, CompletionUsage, CreateChatCompletionRequestArgs, FinishReason,
+        FunctionCall, FunctionName, FunctionObjectArgs, ImageDetail, ImageUrl, ToolChoiceOptions,
     },
     types::embeddings::{CreateEmbeddingRequestArgs, EmbeddingInput},
     Client,
@@ -59,7 +59,7 @@ use crate::traits::FunctionCall as TraitFunctionCall;
 use crate::traits::ToolCall;
 use crate::traits::{
     ChatMessage, ChatRole, CompletionOptions, EmbeddingProvider, ImageData, LLMProvider,
-    LLMResponse, StreamChunk, ToolChoice, ToolDefinition,
+    LLMResponse, StreamChunk, StreamUsage, ToolChoice, ToolDefinition,
 };
 
 const DEFAULT_API_VERSION: &str = "2024-10-21";
@@ -429,6 +429,25 @@ impl AzureOpenAIProvider {
             thinking,
         )
     }
+
+    fn extract_stream_usage(usage: Option<CompletionUsage>) -> Option<StreamUsage> {
+        let (prompt_tokens, completion_tokens, _total_tokens, cache_hit, thinking) =
+            Self::extract_usage(usage);
+
+        if prompt_tokens == 0 && completion_tokens == 0 && cache_hit.is_none() && thinking.is_none()
+        {
+            return None;
+        }
+
+        let mut usage = StreamUsage::new(prompt_tokens, completion_tokens);
+        if let Some(tokens) = cache_hit {
+            usage = usage.with_cache_hit_tokens(tokens);
+        }
+        if let Some(tokens) = thinking {
+            usage = usage.with_thinking_tokens(tokens);
+        }
+        Some(usage)
+    }
 }
 
 // ============================================================================
@@ -749,7 +768,11 @@ impl LLMProvider for AzureOpenAIProvider {
             .model(&self.deployment_name)
             .messages(openai_messages)
             .tools(openai_tools)
-            .stream(true);
+            .stream(true)
+            .stream_options(ChatCompletionStreamOptions {
+                include_usage: Some(true),
+                include_obfuscation: None,
+            });
 
         if let Some(tc) = tool_choice {
             match tc {
@@ -792,6 +815,7 @@ impl LLMProvider for AzureOpenAIProvider {
 
         let mapped = stream.map(|result| match result {
             Ok(response) => {
+                let stream_usage = Self::extract_stream_usage(response.usage.clone());
                 if let Some(choice) = response.choices.first() {
                     if let Some(content) = &choice.delta.content {
                         return Ok(StreamChunk::Content(content.clone()));
@@ -821,8 +845,16 @@ impl LLMProvider for AzureOpenAIProvider {
                         return Ok(StreamChunk::Finished {
                             reason: r.to_string(),
                             ttft_ms: None,
+                            usage: stream_usage,
                         });
                     }
+                }
+                if stream_usage.is_some() {
+                    return Ok(StreamChunk::Finished {
+                        reason: "stop".to_string(),
+                        ttft_ms: None,
+                        usage: stream_usage,
+                    });
                 }
                 Ok(StreamChunk::Content(String::new()))
             }

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -24,6 +24,7 @@ use crate::traits::{
     LLMProvider,
     LLMResponse,
     StreamChunk,
+    StreamUsage,
     ToolCall,
     ToolChoice,
     ToolDefinition, // OODA-06/07/08: Tool + streaming support
@@ -714,6 +715,19 @@ static DEFAULT_PROFILE: ModelProfile = ModelProfile {
 // ============================================================================
 
 impl GeminiProvider {
+    fn stream_usage_from_metadata(usage: Option<&UsageMetadata>) -> Option<StreamUsage> {
+        let usage = usage?;
+        let mut stream_usage =
+            StreamUsage::new(usage.prompt_token_count, usage.candidates_token_count);
+        if usage.cached_content_token_count > 0 {
+            stream_usage = stream_usage.with_cache_hit_tokens(usage.cached_content_token_count);
+        }
+        if usage.thoughts_token_count > 0 {
+            stream_usage = stream_usage.with_thinking_tokens(usage.thoughts_token_count);
+        }
+        Some(stream_usage)
+    }
+
     /// Create a new Gemini provider using Google AI API key.
     ///
     /// # Arguments
@@ -2214,6 +2228,8 @@ impl LLMProvider for GeminiProvider {
         // processed, fall back to pending_sig if the Part itself has no signature.
         let pending_sig: std::sync::Arc<std::sync::Mutex<Option<String>>> =
             std::sync::Arc::new(std::sync::Mutex::new(None));
+        let latest_usage: std::sync::Arc<std::sync::Mutex<Option<StreamUsage>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
 
         // Use flat_map so EVERY StreamChunk from a single SSE packet is emitted.
         //
@@ -2225,6 +2241,7 @@ impl LLMProvider for GeminiProvider {
         let mapped_stream = stream.flat_map(move |result| {
             let fn_call_index = fn_call_index.clone();
             let pending_sig = pending_sig.clone();
+            let latest_usage = latest_usage.clone();
             let items: Vec<crate::error::Result<StreamChunk>> = match result {
                 Ok(bytes) => {
                     let text = String::from_utf8_lossy(&bytes);
@@ -2236,6 +2253,14 @@ impl LLMProvider for GeminiProvider {
                             if let Ok(sse_response) =
                                 serde_json::from_str::<GenerateContentResponse>(json_str)
                             {
+                                let stream_usage = Self::stream_usage_from_metadata(
+                                    sse_response.usage_metadata.as_ref(),
+                                );
+                                if let Some(ref usage) = stream_usage {
+                                    if let Ok(mut latest) = latest_usage.lock() {
+                                        *latest = Some(usage.clone());
+                                    }
+                                }
                                 if let Some(candidates) = sse_response.candidates {
                                     if let Some(candidate) = candidates.first() {
                                         // Process every part — text, thinking, and function calls.
@@ -2315,9 +2340,16 @@ impl LLMProvider for GeminiProvider {
                                                 "SAFETY" => "content_filter",
                                                 _ => reason.as_str(),
                                             };
+                                            let usage = stream_usage.or_else(|| {
+                                                latest_usage
+                                                    .lock()
+                                                    .ok()
+                                                    .and_then(|latest| latest.clone())
+                                            });
                                             chunks.push(Ok(StreamChunk::Finished {
                                                 reason: mapped_reason.to_string(),
                                                 ttft_ms: None,
+                                                usage,
                                             }));
                                         }
                                     }

--- a/src/providers/mock.rs
+++ b/src/providers/mock.rs
@@ -385,6 +385,7 @@ impl LLMProvider for MockAgentProvider {
         chunks.push(Ok(StreamChunk::Finished {
             reason: "stop".to_string(),
             ttft_ms: None,
+            usage: None,
         }));
 
         let stream = futures::stream::iter(chunks);

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -995,6 +995,7 @@ impl LLMProvider for OllamaProvider {
                                 return Ok(TraitStreamChunk::Finished {
                                     reason,
                                     ttft_ms: None,
+                                    usage: None,
                                 });
                             }
                         }

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -11,9 +11,9 @@ use async_openai::{
         ChatCompletionRequestMessageContentPartText, ChatCompletionRequestSystemMessageArgs,
         ChatCompletionRequestToolMessageArgs, ChatCompletionRequestUserMessageArgs,
         ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
-        ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionTools, CompletionUsage,
-        CreateChatCompletionRequestArgs, FinishReason, FunctionCall, FunctionName,
-        FunctionObjectArgs, ImageDetail, ImageUrl, ToolChoiceOptions,
+        ChatCompletionStreamOptions, ChatCompletionTool, ChatCompletionToolChoiceOption,
+        ChatCompletionTools, CompletionUsage, CreateChatCompletionRequestArgs, FinishReason,
+        FunctionCall, FunctionName, FunctionObjectArgs, ImageDetail, ImageUrl, ToolChoiceOptions,
     },
     types::embeddings::{CreateEmbeddingRequestArgs, EmbeddingInput},
     Client,
@@ -29,7 +29,7 @@ use crate::traits::ImageData;
 use crate::traits::ToolCall;
 use crate::traits::{
     ChatMessage, ChatRole, CompletionOptions, EmbeddingProvider, LLMProvider, LLMResponse,
-    StreamChunk, ToolChoice, ToolDefinition,
+    StreamChunk, StreamUsage, ToolChoice, ToolDefinition,
 };
 
 /// OpenAI provider for text completion and embeddings.
@@ -151,6 +151,59 @@ impl OpenAIProvider {
             m if m.contains("text-embedding-ada") => 1536,
             _ => 1536, // Default
         }
+    }
+
+    fn extract_usage(
+        usage: Option<CompletionUsage>,
+    ) -> (usize, usize, usize, Option<usize>, Option<usize>) {
+        let usage = usage.unwrap_or(CompletionUsage {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        let cache_hit_tokens = usage
+            .prompt_tokens_details
+            .as_ref()
+            .and_then(|d| d.cached_tokens)
+            .map(|t| t as usize);
+        let thinking_tokens = usage
+            .completion_tokens_details
+            .as_ref()
+            .and_then(|d| d.reasoning_tokens)
+            .map(|t| t as usize);
+
+        (
+            usage.prompt_tokens as usize,
+            usage.completion_tokens as usize,
+            usage.total_tokens as usize,
+            cache_hit_tokens,
+            thinking_tokens,
+        )
+    }
+
+    fn extract_stream_usage(usage: Option<CompletionUsage>) -> Option<StreamUsage> {
+        let (prompt_tokens, completion_tokens, _total_tokens, cache_hit_tokens, thinking_tokens) =
+            Self::extract_usage(usage);
+
+        if prompt_tokens == 0
+            && completion_tokens == 0
+            && cache_hit_tokens.is_none()
+            && thinking_tokens.is_none()
+        {
+            return None;
+        }
+
+        let mut usage = StreamUsage::new(prompt_tokens, completion_tokens);
+        if let Some(tokens) = cache_hit_tokens {
+            usage = usage.with_cache_hit_tokens(tokens);
+        }
+        if let Some(tokens) = thinking_tokens {
+            usage = usage.with_thinking_tokens(tokens);
+        }
+        Some(usage)
     }
 
     /// Convert chat messages to OpenAI format.
@@ -399,32 +452,13 @@ impl LLMProvider for OpenAIProvider {
 
         let content = choice.message.content.clone().unwrap_or_default();
 
-        let usage = response.usage.clone().unwrap_or(CompletionUsage {
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            total_tokens: 0,
-            prompt_tokens_details: None,
-            completion_tokens_details: None,
-        });
-
-        // Extract cache hit tokens (available in async-openai 0.33 via prompt_tokens_details)
-        let cache_hit_tokens = usage
-            .prompt_tokens_details
-            .as_ref()
-            .and_then(|d| d.cached_tokens)
-            .map(|t| t as usize);
-
-        // Extract reasoning tokens (available in async-openai 0.33 via completion_tokens_details)
-        let thinking_tokens = usage
-            .completion_tokens_details
-            .as_ref()
-            .and_then(|d| d.reasoning_tokens)
-            .map(|t| t as usize);
+        let (prompt_tokens, completion_tokens, total_tokens, cache_hit_tokens, thinking_tokens) =
+            Self::extract_usage(response.usage.clone());
 
         // Log extracted token counts
         debug!(
             "OpenAI token usage - prompt: {}, completion: {}, total: {}, cached: {:?}, reasoning: {:?}",
-            usage.prompt_tokens, usage.completion_tokens, usage.total_tokens,
+            prompt_tokens, completion_tokens, total_tokens,
             cache_hit_tokens, thinking_tokens
         );
 
@@ -433,9 +467,9 @@ impl LLMProvider for OpenAIProvider {
 
         Ok(LLMResponse {
             content,
-            prompt_tokens: usage.prompt_tokens as usize,
-            completion_tokens: usage.completion_tokens as usize,
-            total_tokens: usage.total_tokens as usize,
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
             model: response.model,
             finish_reason: choice.finish_reason.map(|r| format!("{:?}", r)),
             tool_calls: Vec::new(),
@@ -566,34 +600,17 @@ impl LLMProvider for OpenAIProvider {
 
         let content = choice.message.content.clone().unwrap_or_default();
 
-        let usage = response.usage.clone().unwrap_or(CompletionUsage {
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            total_tokens: 0,
-            prompt_tokens_details: None,
-            completion_tokens_details: None,
-        });
-
-        let cache_hit_tokens = usage
-            .prompt_tokens_details
-            .as_ref()
-            .and_then(|d| d.cached_tokens)
-            .map(|t| t as usize);
-
-        let thinking_tokens = usage
-            .completion_tokens_details
-            .as_ref()
-            .and_then(|d| d.reasoning_tokens)
-            .map(|t| t as usize);
+        let (prompt_tokens, completion_tokens, total_tokens, cache_hit_tokens, thinking_tokens) =
+            Self::extract_usage(response.usage.clone());
 
         let mut metadata = HashMap::new();
         metadata.insert("response_id".to_string(), serde_json::json!(response.id));
 
         Ok(LLMResponse {
             content,
-            prompt_tokens: usage.prompt_tokens as usize,
-            completion_tokens: usage.completion_tokens as usize,
-            total_tokens: usage.total_tokens as usize,
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
             model: response.model,
             finish_reason: choice.finish_reason.map(|r| format!("{:?}", r)),
             tool_calls,
@@ -683,7 +700,11 @@ impl LLMProvider for OpenAIProvider {
             .model(&self.model)
             .messages(openai_messages)
             .tools(openai_tools)
-            .stream(true); // Enable streaming
+            .stream(true)
+            .stream_options(ChatCompletionStreamOptions {
+                include_usage: Some(true),
+                include_obfuscation: None,
+            }); // Enable streaming and final usage
 
         // Set tool choice if specified.
         // In async-openai 0.33, Auto/Required are ChatCompletionToolChoiceOption::Mode(...)
@@ -735,6 +756,8 @@ impl LLMProvider for OpenAIProvider {
         let mapped_stream = stream.map(|result| {
             match result {
                 Ok(response) => {
+                    let stream_usage = Self::extract_stream_usage(response.usage.clone());
+
                     let choice = response.choices.first();
                     if let Some(choice) = choice {
                         // Stream content chunks immediately
@@ -773,8 +796,16 @@ impl LLMProvider for OpenAIProvider {
                             return Ok(StreamChunk::Finished {
                                 reason: reason.to_string(),
                                 ttft_ms: None,
+                                usage: stream_usage,
                             });
                         }
+                    }
+                    if stream_usage.is_some() {
+                        return Ok(StreamChunk::Finished {
+                            reason: "stop".to_string(),
+                            ttft_ms: None,
+                            usage: stream_usage,
+                        });
                     }
                     // Empty chunk (no content or tool calls)
                     Ok(StreamChunk::Content(String::new()))

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -48,7 +48,7 @@ use tracing::{debug, instrument, warn};
 use crate::error::{LlmError, Result};
 use crate::traits::{
     ChatMessage, ChatRole, CompletionOptions, EmbeddingProvider, FunctionCall, ImageData,
-    LLMProvider, LLMResponse, StreamChunk, ToolCall, ToolChoice, ToolDefinition,
+    LLMProvider, LLMResponse, StreamChunk, StreamUsage, ToolCall, ToolChoice, ToolDefinition,
 };
 
 // ============================================================================
@@ -1318,6 +1318,7 @@ impl LLMProvider for OpenRouterProvider {
         // when the next chunk contains the rest: " -p ./demo/snake\"}"
         // HOW: Buffer incomplete lines across chunks, only process complete lines (ending in \n)
         let mut line_buffer = String::new();
+        let mut latest_usage: Option<StreamUsage> = None;
 
         let stream = response
             .bytes_stream()
@@ -1345,6 +1346,7 @@ impl LLMProvider for OpenRouterProvider {
                             chunks.push(StreamChunk::Finished {
                                 reason: "stop".to_string(),
                                 ttft_ms: None,
+                                usage: latest_usage.clone(),
                             });
                             continue;
                         }
@@ -1352,6 +1354,12 @@ impl LLMProvider for OpenRouterProvider {
                         if let Ok(chunk_response) =
                             serde_json::from_str::<StreamChunkResponse>(data)
                         {
+                            if let Some(usage) = chunk_response.usage.as_ref() {
+                                latest_usage = Some(StreamUsage::new(
+                                    usage.prompt_tokens as usize,
+                                    usage.completion_tokens as usize,
+                                ));
+                            }
                             // OpenRouter mid-stream error (HTTP 200, error in body).
                             // Return Err so flat_map propagates it and the consumer
                             // can stop processing.
@@ -1405,6 +1413,7 @@ impl LLMProvider for OpenRouterProvider {
                                     chunks.push(StreamChunk::Finished {
                                         reason,
                                         ttft_ms: None,
+                                        usage: latest_usage.clone(),
                                     });
                                 }
                             }

--- a/src/providers/vscode/stream.rs
+++ b/src/providers/vscode/stream.rs
@@ -78,6 +78,20 @@ use tracing::{debug, warn};
 
 use super::error::{Result, VsCodeError};
 use super::types::ChatCompletionChunk;
+use crate::traits::StreamUsage;
+
+fn stream_usage_from_chunk(chunk: &ChatCompletionChunk) -> Option<StreamUsage> {
+    let usage = chunk.usage.as_ref()?;
+    let mut stream_usage = StreamUsage::new(usage.prompt_tokens, usage.completion_tokens);
+    if let Some(cached_tokens) = usage
+        .prompt_tokens_details
+        .as_ref()
+        .and_then(|details| details.cached_tokens)
+    {
+        stream_usage = stream_usage.with_cache_hit_tokens(cached_tokens);
+    }
+    Some(stream_usage)
+}
 
 /// Parse SSE stream from HTTP response.
 ///
@@ -226,6 +240,7 @@ pub(super) fn parse_sse_stream_with_tools(
                     return Ok(Some(StreamChunk::Finished {
                         reason: "stop".to_string(),
                         ttft_ms: None,
+                        usage: None,
                     }));
                 }
 
@@ -239,6 +254,7 @@ pub(super) fn parse_sse_stream_with_tools(
                                 return Ok(Some(StreamChunk::Finished {
                                     reason: finish_reason.clone(),
                                     ttft_ms: None,
+                                    usage: stream_usage_from_chunk(&chunk),
                                 }));
                             }
 
@@ -302,6 +318,7 @@ pub(super) fn parse_sse_stream_with_tools(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::traits::StreamChunk;
 
     // =========================================================================
     // SSE Line Recognition Tests
@@ -413,6 +430,52 @@ mod tests {
 
         assert!(chunk.choices[0].delta.content.is_none());
         assert_eq!(chunk.choices[0].finish_reason, Some("stop".to_string()));
+    }
+
+    #[test]
+    fn test_streaming_finish_usage_is_preserved() {
+        let json = r#"{
+            "id": "chatcmpl-stream123",
+            "object": "chat.completion.chunk",
+            "created": 1699876543,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 20,
+                "completion_tokens": 50,
+                "total_tokens": 70,
+                "prompt_tokens_details": {
+                    "cached_tokens": 12
+                }
+            }
+        }"#;
+
+        let chunk: ChatCompletionChunk = serde_json::from_str(json).unwrap();
+        let finished = StreamChunk::Finished {
+            reason: "stop".to_string(),
+            ttft_ms: None,
+            usage: stream_usage_from_chunk(&chunk),
+        };
+
+        match finished {
+            StreamChunk::Finished {
+                reason,
+                usage: Some(usage),
+                ..
+            } => {
+                assert_eq!(reason, "stop");
+                assert_eq!(usage.prompt_tokens, 20);
+                assert_eq!(usage.completion_tokens, 50);
+                assert_eq!(usage.cache_hit_tokens, Some(12));
+            }
+            other => panic!("unexpected chunk: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -225,6 +225,43 @@ impl ToolResult {
 ///
 /// OODA-04: Added ThinkingContent for extended thinking/reasoning streaming.
 /// OODA-10: Added budget_remaining for thinking budget display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamUsage {
+    /// Tokens in the prompt/input.
+    pub prompt_tokens: usize,
+    /// Tokens in the completion/output.
+    pub completion_tokens: usize,
+    /// Tokens served from cache, if the provider reports them.
+    pub cache_hit_tokens: Option<usize>,
+    /// Reasoning/thinking tokens, if the provider reports them.
+    pub thinking_tokens: Option<usize>,
+}
+
+impl StreamUsage {
+    pub fn new(prompt_tokens: usize, completion_tokens: usize) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+            cache_hit_tokens: None,
+            thinking_tokens: None,
+        }
+    }
+
+    pub fn with_cache_hit_tokens(mut self, tokens: usize) -> Self {
+        self.cache_hit_tokens = Some(tokens);
+        self
+    }
+
+    pub fn with_thinking_tokens(mut self, tokens: usize) -> Self {
+        self.thinking_tokens = Some(tokens);
+        self
+    }
+
+    pub fn total_tokens(&self) -> usize {
+        self.prompt_tokens + self.completion_tokens
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum StreamChunk {
     /// Partial content/reasoning text.
@@ -268,6 +305,8 @@ pub enum StreamChunk {
         /// OODA-35: Added for provider-native TTFT.
         #[allow(dead_code)]
         ttft_ms: Option<f64>,
+        /// Optional final usage snapshot reported by the provider.
+        usage: Option<StreamUsage>,
     },
 }
 
@@ -1544,10 +1583,26 @@ mod tests {
         let chunk = StreamChunk::Finished {
             reason: "stop".to_string(),
             ttft_ms: Some(120.5),
+            usage: Some(
+                StreamUsage::new(11, 7)
+                    .with_cache_hit_tokens(5)
+                    .with_thinking_tokens(3),
+            ),
         };
-        if let StreamChunk::Finished { reason, ttft_ms } = chunk {
+        if let StreamChunk::Finished {
+            reason,
+            ttft_ms,
+            usage,
+        } = chunk
+        {
             assert_eq!(reason, "stop");
             assert_eq!(ttft_ms, Some(120.5));
+            let usage = usage.expect("usage");
+            assert_eq!(usage.prompt_tokens, 11);
+            assert_eq!(usage.completion_tokens, 7);
+            assert_eq!(usage.total_tokens(), 18);
+            assert_eq!(usage.cache_hit_tokens, Some(5));
+            assert_eq!(usage.thinking_tokens, Some(3));
         }
     }
 


### PR DESCRIPTION
Closes #58

## What changed

- added `StreamUsage` and attached it to `StreamChunk::Finished`
- propagated final streaming usage through OpenAI, Azure OpenAI, VS Code, Anthropic, OpenRouter, and Gemini paths when providers expose it
- requested streaming usage explicitly for OpenAI/Azure via `stream_options.include_usage`
- left providers without authoritative stream usage as `None` instead of pretending exact counts
- added VS Code stream coverage for final usage preservation

## Validation

- `cargo fmt --all`
- `cargo test -p edgequake-llm --quiet`
- `cargo clippy -p edgequake-llm --all-targets --all-features -- -D warnings`
- `cargo test -p edgequake-llm --test e2e_openai_api test_openai_streaming -- --ignored --nocapture`
- `cargo test -p edgequake-llm --test e2e_gemini test_gemini_streaming -- --ignored --nocapture`

## Notes

This fixes the source-layer contract loss. Downstream consumers still need to read the new terminal usage payload if they currently rebuild streamed responses without it.
