### PR TITLE
release: edgequake-llm v0.5.1 / edgequake-litellm v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-05
+
+### Fixed
+
+- **Streaming usage propagation now survives terminal chunks across providers.**
+  When a provider supplies authoritative usage metadata only at the end of a
+  stream, the Rust core now carries that usage on the terminal stream chunk
+  instead of dropping it before downstream consumers can persist or display it.
+- **LiteLLM Python fallback streaming now preserves final usage accounting.**
+  The synthetic `StreamChunk::Finished` produced from the completed fallback
+  response now includes prompt, completion, cache-hit, and thinking token
+  counts so Python streaming consumers receive the same authoritative usage as
+  non-streaming calls.
+
 ## [0.5.0] - 2026-04-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "edgequake-litellm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "edgequake-llm",
  "futures",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "edgequake-llm"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Python users should use [`edgequake-litellm`](edgequake-litellm/README.md), the 
 
 ```toml
 [dependencies]
-edgequake-llm = "0.5.0"
+edgequake-llm = "0.5.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -36,7 +36,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 ```toml
 [dependencies]
-edgequake-llm = { version = "0.5.0", features = ["bedrock"] }
+edgequake-llm = { version = "0.5.1", features = ["bedrock"] }
 ```
 
 Note: the base crate declares `rust-version = 1.83.0`, but AWS Bedrock dependencies currently require a newer toolchain when the `bedrock` feature is enabled. Use stable Rust for release builds.

--- a/edgequake-litellm/CHANGELOG.md
+++ b/edgequake-litellm/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-05
+
+### Fixed
+
+- **Streaming usage is now preserved in Python fallback mode.** When the
+  package synthesizes a terminal stream chunk from a completed response, it now
+  includes the authoritative prompt, completion, cache-hit, and thinking token
+  counts instead of emitting a finished event with missing usage metadata.
+
 ## [0.4.0] - 2026-04-04
 
 ### Added

--- a/edgequake-litellm/Cargo.toml
+++ b/edgequake-litellm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgequake-litellm"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # The core edgequake-llm Rust crate
-edgequake-llm = { path = "..", version = "0.5.0", features = ["bedrock"] }
+edgequake-llm = { path = "..", version = "0.5.1", features = ["bedrock"] }
 
 # PyO3 for Python bindings with stable ABI (Python 3.9+)
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }

--- a/edgequake-litellm/pyproject.toml
+++ b/edgequake-litellm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "edgequake-litellm"
-version = "0.4.0"
+version = "0.4.1"
 description = "Drop-in LiteLLM replacement backed by Rust — same API, 10× lower latency"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Release: edgequake-llm v0.5.1 / edgequake-litellm v0.4.1

### What's Changed

#### Fixed

- **Streaming usage propagation now survives terminal chunks across providers.**
  When a provider supplies authoritative usage metadata only at the end of a stream, the Rust core now carries that usage on the terminal stream chunk instead of dropping it before downstream consumers can persist or display it.

- **LiteLLM Python fallback streaming now preserves final usage accounting.**
  The synthetic `StreamChunk::Finished` produced from the completed fallback response now includes prompt, completion, cache-hit, and thinking token counts so Python streaming consumers receive the same authoritative usage as non-streaming calls.

### Versions bumped

| Crate | Old | New |
|-------|-----|-----|
| `edgequake-llm` | 0.5.0 | 0.5.1 |
| `edgequake-litellm` | 0.4.0 | 0.4.1 |

### Release checklist

- [x] CHANGELOG.md updated
- [x] Cargo.toml versions bumped
- [x] Cargo.lock updated
- [x] edgequake-litellm versions updated
- [x] cargo check passes

### Post-merge

After this PR merges to `main`, push the `v0.5.1` tag to trigger the `publish.yml` workflow which handles:
- crates.io publish of `edgequake-llm`
- GitHub Release creation with notes extracted from CHANGELOG.md