### PR TITLE
fix: honor Anthropic auth token fallback for POE

### DIFF
--- a/src/factory.rs
+++ b/src/factory.rs
@@ -200,10 +200,8 @@ impl ProviderFactory {
         }
 
         // Anthropic detection
-        if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
-            if !api_key.is_empty() {
-                return Self::create(ProviderType::Anthropic);
-            }
+        if AnthropicProvider::resolve_api_key_from_env().is_ok() {
+            return Self::create(ProviderType::Anthropic);
         }
 
         // OODA-73: Gemini detection (GEMINI_API_KEY or GOOGLE_API_KEY)
@@ -575,15 +573,23 @@ impl ProviderFactory {
         config: &ProviderConfig,
         model_name: Option<&str>,
     ) -> Result<(Arc<dyn LLMProvider>, Arc<dyn EmbeddingProvider>)> {
-        // Get API key from environment
+        // Get API key from environment.
+        // WHY: ANTHROPIC_AUTH_TOKEN is a legitimate fallback for Anthropic-
+        // compatible endpoints and must still work when ANTHROPIC_API_KEY is
+        // present but intentionally empty.
         let api_key_var = config.api_key_env.as_deref().unwrap_or("ANTHROPIC_API_KEY");
-        let api_key = std::env::var(api_key_var).map_err(|_| {
-            LlmError::ConfigError(format!("{} not set for Anthropic provider", api_key_var))
-        })?;
-
-        if api_key.is_empty() {
-            return Err(LlmError::ConfigError(format!("{} is empty", api_key_var)));
-        }
+        let api_key = if matches!(api_key_var, "ANTHROPIC_API_KEY" | "ANTHROPIC_AUTH_TOKEN") {
+            AnthropicProvider::resolve_api_key_from_env()?
+        } else {
+            let value = std::env::var(api_key_var).map_err(|_| {
+                LlmError::ConfigError(format!("{} not set for Anthropic provider", api_key_var))
+            })?;
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Err(LlmError::ConfigError(format!("{} is empty", api_key_var)));
+            }
+            trimmed.to_string()
+        };
 
         // Determine model
         let model = model_name
@@ -764,9 +770,7 @@ impl ProviderFactory {
     fn create_anthropic_with_model(
         model: &str,
     ) -> Result<(Arc<dyn LLMProvider>, Arc<dyn EmbeddingProvider>)> {
-        let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
-            LlmError::ConfigError("ANTHROPIC_API_KEY not set for Anthropic provider".to_string())
-        })?;
+        let api_key = AnthropicProvider::resolve_api_key_from_env()?;
 
         let mut provider = AnthropicProvider::new(&api_key);
 
@@ -1614,6 +1618,55 @@ mod tests {
 
         let (llm, _) = ProviderFactory::from_env().unwrap();
         assert_eq!(llm.name(), "mock");
+    }
+
+    #[test]
+    #[serial]
+    fn test_anthropic_auto_detection_uses_auth_token_when_api_key_empty() {
+        std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
+        std::env::remove_var("OLLAMA_HOST");
+        std::env::remove_var("OLLAMA_MODEL");
+        std::env::remove_var("LMSTUDIO_HOST");
+        std::env::remove_var("LMSTUDIO_MODEL");
+        std::env::remove_var("OPENAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+        std::env::remove_var("GOOGLE_API_KEY");
+        std::env::remove_var("GEMINI_API_KEY");
+        std::env::remove_var("OPENROUTER_API_KEY");
+        std::env::remove_var("AZURE_OPENAI_API_KEY");
+
+        std::env::set_var("ANTHROPIC_API_KEY", "");
+        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "poe-token");
+
+        let (llm, _) = ProviderFactory::from_env().unwrap();
+        assert_eq!(llm.name(), "anthropic");
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+    }
+
+    #[test]
+    #[serial]
+    fn test_create_anthropic_from_config_uses_auth_token_fallback() {
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::set_var("ANTHROPIC_API_KEY", "");
+        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "poe-token");
+
+        let config = ProviderConfig {
+            provider_type: ConfigProviderType::Anthropic,
+            api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
+            base_url: Some("https://api.poe.com".to_string()),
+            default_llm_model: Some("claude-sonnet-4-6".to_string()),
+            ..Default::default()
+        };
+
+        let (llm, _) = ProviderFactory::from_config(&config).unwrap();
+        assert_eq!(llm.name(), "anthropic");
+        assert_eq!(llm.model(), "claude-sonnet-4-6");
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
     }
 
     #[test]

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -8,10 +8,11 @@
 //! - `ANTHROPIC_BASE_URL`: Override base URL (for Ollama or proxies)
 //! - `ANTHROPIC_MODEL`: Override default model
 //!
-//! # Models Supported (latest first)
+//! # Models Supported (verified against Anthropic docs)
+//! - Claude Opus 4.7:   `claude-opus-4-7`
 //! - Claude Opus 4.6:   `claude-opus-4-6`
 //! - Claude Sonnet 4.6: `claude-sonnet-4-6`  ← DEFAULT
-//! - Claude Haiku 4.5:  `claude-haiku-4-5`
+//! - Claude Haiku 4.5:  `claude-haiku-4-5` / `claude-haiku-4-5-20251001`
 //! - Claude Sonnet 4.5: `claude-sonnet-4-5-20250929`
 //! - Claude Opus 4.5:   `claude-opus-4-5-20250929`
 //! - Claude Sonnet 3.5: `claude-3-5-sonnet-20241022`
@@ -291,6 +292,27 @@ impl AnthropicProvider {
         }
     }
 
+    /// Resolve the effective API key from environment variables.
+    ///
+    /// WHY: third-party Anthropic-compatible endpoints such as Poe may require
+    /// keeping ANTHROPIC_API_KEY intentionally empty while placing the actual
+    /// credential in ANTHROPIC_AUTH_TOKEN. Empty strings must therefore be
+    /// treated as missing rather than as valid keys.
+    pub(crate) fn resolve_api_key_from_env() -> Result<String> {
+        for var in ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"] {
+            if let Ok(value) = std::env::var(var) {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    return Ok(trimmed.to_string());
+                }
+            }
+        }
+
+        Err(LlmError::ConfigError(
+            "ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN environment variable not set".to_string(),
+        ))
+    }
+
     /// Create a provider from environment variables.
     ///
     /// # Environment Variables
@@ -309,17 +331,10 @@ impl AnthropicProvider {
     ///
     /// See: <https://docs.ollama.com/api/anthropic-compatibility>
     pub fn from_env() -> Result<Self> {
-        // WHY: Support both ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN
-        // Ollama documentation uses ANTHROPIC_AUTH_TOKEN, but ANTHROPIC_API_KEY
-        // is more common. Support both for maximum compatibility.
-        let api_key = std::env::var("ANTHROPIC_API_KEY")
-            .or_else(|_| std::env::var("ANTHROPIC_AUTH_TOKEN"))
-            .map_err(|_| {
-                LlmError::ConfigError(
-                    "ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN environment variable not set"
-                        .to_string(),
-                )
-            })?;
+        // WHY: Support both ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN,
+        // while treating empty values as unset so proxy-compatible setups like
+        // Poe can intentionally leave ANTHROPIC_API_KEY blank.
+        let api_key = Self::resolve_api_key_from_env()?;
 
         let mut provider = Self::new(api_key);
 
@@ -476,9 +491,14 @@ impl AnthropicProvider {
     /// Get context length for a given model.
     pub fn context_length_for_model(model: &str) -> usize {
         match model {
-            // Claude 4.6 series (latest 2026) — simplified naming without date suffix
-            m if m.contains("claude-opus-4-6") => 200_000,
-            m if m.contains("claude-sonnet-4-6") => 200_000,
+            // Verified against Anthropic official docs (20 Apr 2026):
+            // - claude-opus-4-7   → 1M context
+            // - claude-opus-4-6   → 1M context
+            // - claude-sonnet-4-6 → 1M context
+            // - claude-haiku-4-5  → 200k context
+            m if m.contains("claude-opus-4-7") => 1_000_000,
+            m if m.contains("claude-opus-4-6") => 1_000_000,
+            m if m.contains("claude-sonnet-4-6") => 1_000_000,
 
             // Claude 4.5 series (2025)
             m if m.contains("claude-opus-4-5") || m.contains("opus-4.5") => 200_000,
@@ -1244,6 +1264,14 @@ impl LLMProvider for AnthropicProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    fn restore_env(var: &str, value: Option<String>) {
+        match value {
+            Some(v) => std::env::set_var(var, v),
+            None => std::env::remove_var(var),
+        }
+    }
 
     #[test]
     fn test_new_provider() {
@@ -1263,12 +1291,16 @@ mod tests {
     #[test]
     fn test_context_length_for_model() {
         assert_eq!(
+            AnthropicProvider::context_length_for_model("claude-opus-4-7"),
+            1_000_000
+        );
+        assert_eq!(
             AnthropicProvider::context_length_for_model("claude-opus-4-6"),
-            200_000
+            1_000_000
         );
         assert_eq!(
             AnthropicProvider::context_length_for_model("claude-sonnet-4-6"),
-            200_000
+            1_000_000
         );
         assert_eq!(
             AnthropicProvider::context_length_for_model("claude-opus-4-5-20250929"),
@@ -1373,6 +1405,50 @@ mod tests {
         assert!(headers.contains_key("x-api-key"));
         assert!(headers.contains_key("anthropic-version"));
         assert!(headers.contains_key(reqwest::header::CONTENT_TYPE));
+    }
+
+    #[test]
+    #[serial]
+    fn test_from_env_falls_back_to_auth_token_when_api_key_empty() {
+        let old_api_key = std::env::var("ANTHROPIC_API_KEY").ok();
+        let old_auth_token = std::env::var("ANTHROPIC_AUTH_TOKEN").ok();
+        let old_base_url = std::env::var("ANTHROPIC_BASE_URL").ok();
+        let old_model = std::env::var("ANTHROPIC_MODEL").ok();
+
+        std::env::set_var("ANTHROPIC_API_KEY", "");
+        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "poe-test-key");
+        std::env::remove_var("ANTHROPIC_BASE_URL");
+        std::env::remove_var("ANTHROPIC_MODEL");
+
+        let provider = AnthropicProvider::from_env().expect("auth token fallback should work");
+        assert_eq!(provider.api_key(), "poe-test-key");
+
+        restore_env("ANTHROPIC_API_KEY", old_api_key);
+        restore_env("ANTHROPIC_AUTH_TOKEN", old_auth_token);
+        restore_env("ANTHROPIC_BASE_URL", old_base_url);
+        restore_env("ANTHROPIC_MODEL", old_model);
+    }
+
+    #[test]
+    #[serial]
+    fn test_from_env_prefers_non_empty_api_key_when_both_are_set() {
+        let old_api_key = std::env::var("ANTHROPIC_API_KEY").ok();
+        let old_auth_token = std::env::var("ANTHROPIC_AUTH_TOKEN").ok();
+        let old_base_url = std::env::var("ANTHROPIC_BASE_URL").ok();
+        let old_model = std::env::var("ANTHROPIC_MODEL").ok();
+
+        std::env::set_var("ANTHROPIC_API_KEY", "primary-key");
+        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "fallback-key");
+        std::env::remove_var("ANTHROPIC_BASE_URL");
+        std::env::remove_var("ANTHROPIC_MODEL");
+
+        let provider = AnthropicProvider::from_env().expect("primary api key should work");
+        assert_eq!(provider.api_key(), "primary-key");
+
+        restore_env("ANTHROPIC_API_KEY", old_api_key);
+        restore_env("ANTHROPIC_AUTH_TOKEN", old_auth_token);
+        restore_env("ANTHROPIC_BASE_URL", old_base_url);
+        restore_env("ANTHROPIC_MODEL", old_model);
     }
 
     #[test]

--- a/tests/e2e_anthropic.rs
+++ b/tests/e2e_anthropic.rs
@@ -91,7 +91,7 @@ fn test_builder_defaults() {
     assert_eq!(p.base_url(), "https://api.anthropic.com");
     assert_eq!(p.endpoint(), "https://api.anthropic.com/v1/messages");
     assert_eq!(p.api_version(), "2023-06-01");
-    assert_eq!(p.max_context_length(), 200_000);
+    assert_eq!(p.max_context_length(), 1_000_000);
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn test_builder_with_api_key() {
 fn test_builder_with_model() {
     let p = AnthropicProvider::new("k").with_model("claude-opus-4-6");
     assert_eq!(p.model(), "claude-opus-4-6");
-    assert_eq!(p.max_context_length(), 200_000);
+    assert_eq!(p.max_context_length(), 1_000_000);
 }
 
 #[test]
@@ -195,9 +195,16 @@ fn test_context_length_legacy_models() {
 
 #[test]
 fn test_context_length_claude_4_series() {
+    for model in &["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"] {
+        assert_eq!(
+            AnthropicProvider::context_length_for_model(model),
+            1_000_000,
+            "model {} should be 1M",
+            model
+        );
+    }
+
     for model in &[
-        "claude-opus-4-6",
-        "claude-sonnet-4-6",
         "claude-opus-4-5-20250929",
         "claude-sonnet-4-5-20250929",
         "claude-haiku-4-5",

--- a/tests/e2e_provider_factory.rs
+++ b/tests/e2e_provider_factory.rs
@@ -21,6 +21,7 @@ async fn test_provider_auto_detection_ollama() {
     std::env::remove_var("GOOGLE_API_KEY");
     std::env::remove_var("MISTRAL_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
+    std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
     std::env::remove_var("AZURE_OPENAI_API_KEY");
     std::env::remove_var("AZURE_OPENAI_ENDPOINT");
     std::env::remove_var("AZURE_OPENAI_CONTENTGEN_API_KEY");
@@ -72,6 +73,7 @@ async fn test_provider_auto_detection_openai() {
     std::env::remove_var("MISTRAL_API_KEY");
     std::env::remove_var("OPENROUTER_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
+    std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
     std::env::remove_var("AZURE_OPENAI_API_KEY");
     std::env::remove_var("AZURE_OPENAI_ENDPOINT");
     std::env::remove_var("AZURE_OPENAI_CONTENTGEN_API_KEY");
@@ -117,6 +119,7 @@ async fn test_provider_auto_detection_mock_fallback() {
     std::env::remove_var("MISTRAL_API_KEY");
     std::env::remove_var("OPENROUTER_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
+    std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
     std::env::remove_var("AZURE_OPENAI_API_KEY");
     std::env::remove_var("AZURE_OPENAI_ENDPOINT");
     std::env::remove_var("AZURE_OPENAI_CONTENTGEN_API_KEY");
@@ -150,6 +153,7 @@ async fn test_explicit_provider_override() {
     std::env::remove_var("MISTRAL_API_KEY");
     std::env::remove_var("OPENROUTER_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
+    std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
     std::env::remove_var("AZURE_OPENAI_API_KEY");
     std::env::remove_var("AZURE_OPENAI_ENDPOINT");
     std::env::remove_var("AZURE_OPENAI_CONTENTGEN_API_KEY");
@@ -194,6 +198,7 @@ async fn test_provider_priority_chain() {
     std::env::remove_var("MISTRAL_API_KEY");
     std::env::remove_var("OPENROUTER_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
+    std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
     std::env::remove_var("AZURE_OPENAI_API_KEY");
     std::env::remove_var("AZURE_OPENAI_ENDPOINT");
     std::env::remove_var("AZURE_OPENAI_CONTENTGEN_API_KEY");
@@ -302,6 +307,7 @@ async fn test_embedding_dimension_detection() {
     std::env::remove_var("MISTRAL_API_KEY");
     std::env::remove_var("OPENROUTER_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
+    std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
     std::env::remove_var("AZURE_OPENAI_API_KEY");
     std::env::remove_var("AZURE_OPENAI_ENDPOINT");
     std::env::remove_var("AZURE_OPENAI_CONTENTGEN_API_KEY");
@@ -341,6 +347,7 @@ async fn test_provider_auto_detection_lmstudio() {
     std::env::remove_var("MISTRAL_API_KEY");
     std::env::remove_var("OPENROUTER_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
+    std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
     std::env::remove_var("AZURE_OPENAI_API_KEY");
     std::env::remove_var("AZURE_OPENAI_ENDPOINT");
     std::env::remove_var("AZURE_OPENAI_CONTENTGEN_API_KEY");


### PR DESCRIPTION
## Summary
This PR fixes Anthropic credential resolution for Anthropic-compatible endpoints such as POE.

Closes #68

## Root cause
If `ANTHROPIC_API_KEY` existed but was empty, the provider treated it as authoritative and never fell back to `ANTHROPIC_AUTH_TOKEN`. That produced an empty `x-api-key` header and a 401 authentication failure.

## Changes
- centralize Anthropic env credential resolution
- treat blank env values as unset
- fall back cleanly from `ANTHROPIC_API_KEY` to `ANTHROPIC_AUTH_TOKEN`
- add regression tests for provider and factory behavior
- align current Claude 4 model metadata with official Anthropic docs

## Verification
- `cargo test --locked` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅

## Compatibility
This keeps the real Anthropic Messages API contract unchanged while fixing POE and other Anthropic-compatible base URLs.