### PR TITLE
Release edgequake-llm v0.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.12] - 2026-04-21
+
+### Added
+
+- **Cache-write accounting is now exposed on the normalized response contract.** `LLMResponse` and `StreamUsage` can now carry prompt-cache write tokens separately from cache hits, which gives downstream runtimes enough information to show accurate Anthropic-compatible cost breakdowns.
+- **Shared provider schema normalization utilities.** A new `schema_utils` module centralizes strict-mode budget checks, recursive key stripping, `additionalProperties: false` enforcement, nullable-type conversion, and OpenAI strict-schema normalization helpers for provider adapters.
+
+### Fixed
+
+- **Anthropic tool strict-mode budget handling.** Tool conversion now disables `strict` across the request when the aggregate strict-tool limits would be exceeded, instead of sending a request shape Anthropic-compatible endpoints reject.
+- **Anthropic-compatible streaming no longer drops the final unterminated SSE frame.** The streaming adapters now flush the last buffered `data:` line even when the upstream server closes without a trailing newline, which preserves final tool-call JSON deltas.
+- **Bedrock and Gemini tool schemas are normalized to the provider subset they actually accept.** Bedrock now reuses the Anthropic-compatible schema sanitization path, and Gemini strips unsupported JSON Schema keywords while converting nullable type arrays into Gemini-compatible `nullable: true` declarations.
+
 ## [0.6.11] - 2026-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.11] - 2026-04-20
+
+### Fixed
+
+- **Explicit Anthropic-compatible provider parity is now complete.** The final explicit factory path now carries through `ANTHROPIC_BASE_URL` as well as the blank-value fallback from `ANTHROPIC_API_KEY` to `ANTHROPIC_AUTH_TOKEN`, which is required for real POE-backed EdgeCrab sessions.
+- **Live POE verification now covers the exact explicit-provider path used by downstream apps.** This closes the last gap between unit coverage and real CLI runtime behavior.
+
 ## [0.6.10] - 2026-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.10] - 2026-04-20
+
+### Fixed
+
+- **Explicit Anthropic provider creation now honors the same fallback contract as from-env and config-based setup.** Requests created through the factory path now correctly treat blank `ANTHROPIC_API_KEY` as unset and fall back to `ANTHROPIC_AUTH_TOKEN`, eliminating the last remaining POE runtime path that could still miss the required `x-api-key` header.
+- **Live Anthropic-compatible E2E coverage added.** A real network regression now proves the POE-style path succeeds with `ANTHROPIC_BASE_URL=https://api.poe.com`, `ANTHROPIC_API_KEY=''`, and `ANTHROPIC_AUTH_TOKEN` set.
+
 ## [0.6.9] - 2026-04-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "edgequake-litellm"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "edgequake-llm",
  "futures",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "edgequake-litellm"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "edgequake-llm",
  "futures",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "edgequake-llm"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "edgequake-llm"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "edgequake-llm"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Python users should use [`edgequake-litellm`](edgequake-litellm/README.md), the 
 
 ```toml
 [dependencies]
-edgequake-llm = "0.6.11"
+edgequake-llm = "0.6.12"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -36,10 +36,16 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 ```toml
 [dependencies]
-edgequake-llm = { version = "0.6.11", features = ["bedrock"] }
+edgequake-llm = { version = "0.6.12", features = ["bedrock"] }
 ```
 
-Note: the repository is now pinned to Rust 1.95.0, and the Bedrock integration is verified against the latest published AWS SDK crate set, including the current Bedrock runtime releaseg the current Bedrock runtime release.
+Note: the repository is now pinned to Rust 1.95.0, and the Bedrock integration is verified against the latest published AWS SDK crate set, including the current Bedrock runtime release.
+
+Provider compatibility highlights in this release:
+
+- Anthropic-compatible adapters now preserve final streamed tool-call deltas even when the upstream SSE stream ends without a trailing newline.
+- Provider-side schema normalization now aligns Anthropic, Bedrock, and Gemini tool declarations with the stricter subsets those APIs actually accept.
+- Normalized usage reporting distinguishes cache writes from cache hits where the upstream provider reports both.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Python users should use [`edgequake-litellm`](edgequake-litellm/README.md), the 
 
 ```toml
 [dependencies]
-edgequake-llm = "0.6.9"
+edgequake-llm = "0.6.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -36,7 +36,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 ```toml
 [dependencies]
-edgequake-llm = { version = "0.6.9", features = ["bedrock"] }
+edgequake-llm = { version = "0.6.10", features = ["bedrock"] }
 ```
 
 Note: the repository is now pinned to Rust 1.95.0, and the Bedrock integration is verified against the latest published AWS SDK crate set, including the current Bedrock runtime releaseg the current Bedrock runtime release.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Python users should use [`edgequake-litellm`](edgequake-litellm/README.md), the 
 
 ```toml
 [dependencies]
-edgequake-llm = "0.6.10"
+edgequake-llm = "0.6.11"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -36,7 +36,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 ```toml
 [dependencies]
-edgequake-llm = { version = "0.6.10", features = ["bedrock"] }
+edgequake-llm = { version = "0.6.11", features = ["bedrock"] }
 ```
 
 Note: the repository is now pinned to Rust 1.95.0, and the Bedrock integration is verified against the latest published AWS SDK crate set, including the current Bedrock runtime releaseg the current Bedrock runtime release.

--- a/edgequake-litellm/CHANGELOG.md
+++ b/edgequake-litellm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.10] - 2026-04-20
+
+### Changed
+
+- Synced the Python bridge metadata to edgequake-llm 0.6.10 so downstream consumers pick up the final explicit Anthropic/POE provider-path fix.
+
 ## [0.6.9] - 2026-04-20
 
 ### Fixed

--- a/edgequake-litellm/CHANGELOG.md
+++ b/edgequake-litellm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.11] - 2026-04-20
+
+### Changed
+
+- Synced the Python bridge metadata to edgequake-llm 0.6.11 so downstream consumers pick up the final POE explicit-provider parity fix.
+
 ## [0.6.10] - 2026-04-20
 
 ### Changed

--- a/edgequake-litellm/Cargo.toml
+++ b/edgequake-litellm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # The core edgequake-llm Rust crate
-edgequake-llm = { path = "..", version = "0.6.11", features = ["bedrock"] }
+edgequake-llm = { path = "..", version = "0.6.12", features = ["bedrock"] }
 
 # PyO3 for Python bindings with stable ABI (Python 3.9+)
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }

--- a/edgequake-litellm/Cargo.toml
+++ b/edgequake-litellm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgequake-litellm"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # The core edgequake-llm Rust crate
-edgequake-llm = { path = "..", version = "0.6.10", features = ["bedrock"] }
+edgequake-llm = { path = "..", version = "0.6.11", features = ["bedrock"] }
 
 # PyO3 for Python bindings with stable ABI (Python 3.9+)
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }

--- a/edgequake-litellm/Cargo.toml
+++ b/edgequake-litellm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgequake-litellm"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # The core edgequake-llm Rust crate
-edgequake-llm = { path = "..", version = "0.6.9", features = ["bedrock"] }
+edgequake-llm = { path = "..", version = "0.6.10", features = ["bedrock"] }
 
 # PyO3 for Python bindings with stable ABI (Python 3.9+)
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }

--- a/edgequake-litellm/pyproject.toml
+++ b/edgequake-litellm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "edgequake-litellm"
-version = "0.6.10"
+version = "0.6.11"
 description = "Drop-in LiteLLM replacement backed by Rust — same API, 10× lower latency"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/edgequake-litellm/pyproject.toml
+++ b/edgequake-litellm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "edgequake-litellm"
-version = "0.6.9"
+version = "0.6.10"
 description = "Drop-in LiteLLM replacement backed by Rust — same API, 10× lower latency"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/examples/advanced/middleware.rs
+++ b/examples/advanced/middleware.rs
@@ -162,6 +162,7 @@ fn simulate_response() -> LLMResponse {
         tool_calls: vec![],
         metadata: HashMap::new(),
         cache_hit_tokens: None,
+        cache_write_tokens: None,
         thinking_tokens: None,
         thinking_content: None,
     }

--- a/logs/2025-07-24-schema-utils-strict-budget-fix.md
+++ b/logs/2025-07-24-schema-utils-strict-budget-fix.md
@@ -1,0 +1,21 @@
+# Task Log: Schema Utils & Strict-Budget Fix
+
+## Actions
+- Created `src/providers/schema_utils.rs` — shared DRY module with 6 composable utilities: `count_optional_params`, `count_union_type_params`, `check_anthropic_strict_budget`, `strip_keys_recursive`, `ensure_additional_properties_false`, `convert_type_arrays_to_nullable`, `normalize_for_openai_strict`
+- Fixed `anthropic.rs` `convert_tools()` — now checks strict-mode budget (20 tools, 24 optional params, 16 union-type params) and strips `strict` from ALL tools when exceeded
+- Fixed `bedrock.rs` `build_tool_config_with_aliases()` — now applies schema sanitization (strip unsupported constraints + additionalProperties:false) since Bedrock uses Claude
+- Added 3 targeted Anthropic tests for strict-budget enforcement
+- Registered `schema_utils` module in `providers/mod.rs`
+
+## Decisions
+- OpenAI provider left as-is: `async-openai` crate doesn't expose `.strict()` on FunctionObjectArgs, so strict mode is never sent (safe default)
+- Gemini provider left as-is: already has comprehensive sanitization, refactoring to shared utils is optional
+- When Anthropic budget exceeded, strip strict from ALL tools (not selective) — matches Anthropic's own guidance and Claude Code's pattern
+
+## Next Steps
+- Test with EdgeCrab's 94 tools against `anthropic/claude-sonnet-4.6` to verify the "142 optional parameters" error is resolved
+- Consider future work: per-tool `strict` opt-in (like Claude Code) vs. the current default-true approach in `traits.rs`
+
+## Lessons
+- Anthropic strict mode has aggregate limits across ALL tools in a request (24 optional params total), not per-tool limits — this is why 94 tools with `strict: true` default fails
+- Claude Code gates strict behind 3 conditions: feature flag AND per-tool flag AND model support — a good defensive pattern

--- a/logs/2026-04-20-10-12-beastmode-chatmode-log.md
+++ b/logs/2026-04-20-10-12-beastmode-chatmode-log.md
@@ -1,0 +1,9 @@
+# Task logs
+
+Actions: pinned edgequake-llm and edgecrab to Rust 1.95.0, added repo toolchain files, and verified Bedrock builds with the latest AWS SDK crates.
+
+Decisions: kept aws-sdk-bedrockruntime at 1.129.0 and aws-config at 1.8.15 because they are already the latest published versions confirmed from upstream docs.
+
+Next steps: optionally commit and tag these toolchain updates if you want them published immediately.
+
+Lessons/insights: disabling the Bedrock SDK service crate default features removed the legacy TLS path and left cargo-audit with warnings only, not blocking vulnerabilities.

--- a/logs/2026-04-20-10-27-beastmode-chatmode-log.md
+++ b/logs/2026-04-20-10-27-beastmode-chatmode-log.md
@@ -1,0 +1,6 @@
+# Task logs
+
+- Actions: Bumped edgequake-llm to 0.6.8, updated README and CHANGELOG, ran fmt/clippy/tests/audit/publish dry-run, published to crates.io, tagged v0.6.8, and switched edgecrab to the registry release.
+- Decisions: Released as 0.6.8 because 0.6.7 was tagged locally but not live on crates.io; removed the temporary edgecrab path override after registry confirmation.
+- Next steps: Let docs.rs refresh to the new version and optionally commit the edgecrab dependency bump on its working branch.
+- Lessons/insights: crates.io UI and docs.rs can lag after a successful publish, so the crates.io API max_version check is the reliable immediate verification signal.

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1373,13 +1373,12 @@ impl ProviderFactory {
                 Ok(Arc::new(provider))
             }
             ProviderType::Anthropic => {
-                let api_key = AnthropicProvider::resolve_api_key_from_env()?;
-                // Anthropic provider with specific model.
-                // WHY: explicit provider/model calls in downstream apps such as
-                // EdgeCrab route through create_llm_provider(), so this path must
-                // honor the same blank-value fallback semantics as from_env().
-                let provider = AnthropicProvider::new(api_key).with_model(model);
-                Ok(Arc::new(provider))
+                // Reuse the shared constructor so the explicit provider/model path
+                // stays behaviorally identical to from_env() and config-based setup.
+                // WHY: Anthropic-compatible gateways such as POE require BOTH the
+                // blank-value credential fallback and ANTHROPIC_BASE_URL support.
+                let (provider, _) = Self::create_anthropic_with_model(model)?;
+                Ok(provider)
             }
             ProviderType::OpenRouter => {
                 let api_key = std::env::var("OPENROUTER_API_KEY").map_err(|_| {

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1373,12 +1373,11 @@ impl ProviderFactory {
                 Ok(Arc::new(provider))
             }
             ProviderType::Anthropic => {
-                let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
-                    LlmError::ConfigError(
-                        "ANTHROPIC_API_KEY required for Anthropic LLM provider".to_string(),
-                    )
-                })?;
-                // Anthropic provider with specific model
+                let api_key = AnthropicProvider::resolve_api_key_from_env()?;
+                // Anthropic provider with specific model.
+                // WHY: explicit provider/model calls in downstream apps such as
+                // EdgeCrab route through create_llm_provider(), so this path must
+                // honor the same blank-value fallback semantics as from_env().
                 let provider = AnthropicProvider::new(api_key).with_model(model);
                 Ok(Arc::new(provider))
             }
@@ -1664,6 +1663,23 @@ mod tests {
         let (llm, _) = ProviderFactory::from_config(&config).unwrap();
         assert_eq!(llm.name(), "anthropic");
         assert_eq!(llm.model(), "claude-sonnet-4-6");
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+    }
+
+    #[test]
+    #[serial]
+    fn test_create_llm_provider_anthropic_uses_auth_token_fallback() {
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::set_var("ANTHROPIC_API_KEY", "");
+        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "poe-token");
+
+        let provider = ProviderFactory::create_llm_provider("anthropic", "claude-haiku-4-5")
+            .expect("anthropic LLM provider should use auth token fallback");
+        assert_eq!(provider.name(), "anthropic");
+        assert_eq!(provider.model(), "claude-haiku-4-5");
 
         std::env::remove_var("ANTHROPIC_API_KEY");
         std::env::remove_var("ANTHROPIC_AUTH_TOKEN");

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -138,6 +138,8 @@ struct AnthropicTool {
     name: String,
     description: String,
     input_schema: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    strict: Option<bool>,
 }
 
 /// Request body for messages endpoint
@@ -256,6 +258,136 @@ struct MessageDeltaData {
 #[allow(dead_code)] // Fields used for deserialization only
 struct DeltaUsage {
     output_tokens: u32,
+}
+
+fn schema_declares_object(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(kind) => kind == "object",
+        serde_json::Value::Array(values) => values.iter().any(schema_declares_object),
+        _ => false,
+    }
+}
+
+fn append_constraint_note(
+    notes: &mut Vec<String>,
+    label: &str,
+    value: Option<serde_json::Value>,
+    formatter: impl FnOnce(serde_json::Value) -> String,
+) {
+    if let Some(value) = value {
+        notes.push(format!("{label}: {}", formatter(value)));
+    }
+}
+
+fn append_notes_to_description(
+    description: Option<serde_json::Value>,
+    notes: &[String],
+) -> Option<serde_json::Value> {
+    if notes.is_empty() {
+        return description;
+    }
+
+    let joined_notes = notes.join(" ");
+    let updated = match description {
+        Some(serde_json::Value::String(existing)) if !existing.trim().is_empty() => {
+            format!("{existing} Constraints: {joined_notes}")
+        }
+        _ => format!("Constraints: {joined_notes}"),
+    };
+
+    Some(serde_json::Value::String(updated))
+}
+
+fn sanitize_parameters(params: serde_json::Value) -> serde_json::Value {
+    match params {
+        serde_json::Value::Object(mut obj) => {
+            let mut removed_constraint_notes = Vec::new();
+
+            append_constraint_note(
+                &mut removed_constraint_notes,
+                "minimum",
+                obj.remove("minimum"),
+                |value| format!(">= {value}"),
+            );
+            append_constraint_note(
+                &mut removed_constraint_notes,
+                "maximum",
+                obj.remove("maximum"),
+                |value| format!("<= {value}"),
+            );
+            append_constraint_note(
+                &mut removed_constraint_notes,
+                "minLength",
+                obj.remove("minLength"),
+                |value| format!("at least {value} characters"),
+            );
+            append_constraint_note(
+                &mut removed_constraint_notes,
+                "maxLength",
+                obj.remove("maxLength"),
+                |value| format!("at most {value} characters"),
+            );
+            append_constraint_note(
+                &mut removed_constraint_notes,
+                "minItems",
+                obj.remove("minItems"),
+                |value| format!("at least {value} items"),
+            );
+            append_constraint_note(
+                &mut removed_constraint_notes,
+                "maxItems",
+                obj.remove("maxItems"),
+                |value| format!("at most {value} items"),
+            );
+
+            if obj.get("type").is_some_and(schema_declares_object)
+                && !obj.contains_key("additionalProperties")
+            {
+                obj.insert(
+                    "additionalProperties".into(),
+                    serde_json::Value::Bool(false),
+                );
+            }
+
+            let description =
+                append_notes_to_description(obj.remove("description"), &removed_constraint_notes);
+            if let Some(description) = description {
+                obj.insert("description".into(), description);
+            }
+
+            let sanitized = obj
+                .into_iter()
+                .map(|(key, value)| (key, sanitize_parameters(value)))
+                .collect::<serde_json::Map<String, serde_json::Value>>();
+
+            serde_json::Value::Object(sanitized)
+        }
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(sanitize_parameters).collect())
+        }
+        other => other,
+    }
+}
+
+fn drain_sse_data_lines(line_buffer: &mut String) -> Vec<String> {
+    let mut data_lines = Vec::new();
+
+    while let Some(newline_idx) = line_buffer.find('\n') {
+        let line = line_buffer[..newline_idx].trim().to_string();
+        line_buffer.drain(..=newline_idx);
+
+        // Skip empty lines, comments, and explicit SSE event-name lines.
+        // We rely on the JSON payload's own `type` field for dispatch.
+        if line.is_empty() || line.starts_with(':') || line.starts_with("event:") {
+            continue;
+        }
+
+        if let Some(data) = line.strip_prefix("data: ") {
+            data_lines.push(data.to_string());
+        }
+    }
+
+    data_lines
 }
 
 // ============================================================================
@@ -711,13 +843,49 @@ impl AnthropicProvider {
     }
 
     /// Convert EdgeCode ToolDefinition to Anthropic format.
+    ///
+    /// Enforces Anthropic's strict-mode budget:
+    /// - Max 20 strict tools
+    /// - Max 24 optional parameters across all strict tools
+    /// - Max 16 union-type parameters across all strict tools
+    ///
+    /// When the budget is exceeded, `strict` is stripped from ALL tools
+    /// (following Anthropic's guidance: "Mark only critical tools as strict.
+    /// If you have many tools, reserve it for tools where schema violations
+    /// cause real problems.")
     fn convert_tools(tools: &[ToolDefinition]) -> Vec<AnthropicTool> {
+        use super::schema_utils::check_anthropic_strict_budget;
+
+        // First pass: check the strict-mode budget
+        let budget = check_anthropic_strict_budget(tools.iter().map(|t| {
+            let is_strict = t.function.strict.unwrap_or(false);
+            (is_strict, &t.function.parameters)
+        }));
+
+        if budget.exceeds_limits {
+            tracing::info!(
+                strict_tools = budget.total_strict_tools,
+                optional_params = budget.total_optional_params,
+                union_type_params = budget.total_union_type_params,
+                "Anthropic strict-mode budget exceeded — disabling strict on all tools"
+            );
+        }
+
         tools
             .iter()
-            .map(|tool| AnthropicTool {
-                name: tool.function.name.clone(),
-                description: tool.function.description.clone(),
-                input_schema: tool.function.parameters.clone(),
+            .map(|tool| {
+                let strict = if budget.exceeds_limits {
+                    None // Strip strict when budget exceeded
+                } else {
+                    tool.function.strict
+                };
+
+                AnthropicTool {
+                    name: tool.function.name.clone(),
+                    description: tool.function.description.clone(),
+                    input_schema: sanitize_parameters(tool.function.parameters.clone()),
+                    strict,
+                }
             })
             .collect()
     }
@@ -770,8 +938,12 @@ impl AnthropicProvider {
 
         metadata.insert("response_id".to_string(), serde_json::json!(response.id));
 
-        // Calculate cache hit tokens if available
+        // Calculate cache tokens if available
         let cache_hit_tokens = response.usage.cache_read_input_tokens.map(|t| t as usize);
+        let cache_write_tokens = response
+            .usage
+            .cache_creation_input_tokens
+            .map(|t| t as usize);
 
         LLMResponse {
             content,
@@ -783,6 +955,7 @@ impl AnthropicProvider {
             tool_calls,
             metadata,
             cache_hit_tokens,
+            cache_write_tokens,
             thinking_tokens: None,
             thinking_content: None,
         }
@@ -959,6 +1132,13 @@ impl LLMProvider for AnthropicProvider {
 
         let stream = response
             .bytes_stream()
+            // WHY: Some Anthropic-compatible endpoints close the HTTP stream
+            // without a trailing newline on the final `data:` line. Appending a
+            // synthetic newline forces the last buffered event to be drained
+            // instead of being silently dropped.
+            .chain(futures::stream::once(async {
+                Ok::<_, reqwest::Error>("\n".into())
+            }))
             .map(move |chunk| {
                 let chunk = chunk.map_err(|e| LlmError::NetworkError(e.to_string()))?;
                 let text = String::from_utf8_lossy(&chunk);
@@ -967,30 +1147,20 @@ impl LLMProvider for AnthropicProvider {
 
                 let mut result = String::new();
 
-                while let Some(newline_idx) = line_buffer.find('\n') {
-                    let line = line_buffer[..newline_idx].trim().to_string();
-                    line_buffer.drain(..=newline_idx);
-
-                    // Skip empty lines and SSE comment lines (':')
-                    if line.is_empty() || line.starts_with(':') {
-                        continue;
-                    }
-
-                    if let Some(data) = line.strip_prefix("data: ") {
-                        if let Ok(event) = serde_json::from_str::<StreamEvent>(data) {
-                            match event {
-                                StreamEvent::ContentBlockDelta { delta, .. }
-                                    if delta.delta_type == "text_delta" =>
-                                {
-                                    if let Some(text) = delta.text {
-                                        result.push_str(&text);
-                                    }
+                for data in drain_sse_data_lines(&mut line_buffer) {
+                    if let Ok(event) = serde_json::from_str::<StreamEvent>(&data) {
+                        match event {
+                            StreamEvent::ContentBlockDelta { delta, .. }
+                                if delta.delta_type == "text_delta" =>
+                            {
+                                if let Some(text) = delta.text {
+                                    result.push_str(&text);
                                 }
-                                StreamEvent::Error { error } => {
-                                    warn!("Stream error: {}", error.message);
-                                }
-                                _ => {}
                             }
+                            StreamEvent::Error { error } => {
+                                warn!("Stream error: {}", error.message);
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -1113,10 +1283,18 @@ impl LLMProvider for AnthropicProvider {
         let mut finished_emitted = false;
         let mut prompt_tokens = 0usize;
         let mut cache_hit_tokens = None;
+        let mut cache_write_tokens_stream = None;
         let mut latest_output_tokens = 0usize;
 
         let stream = response
             .bytes_stream()
+            // WHY: Some Anthropic-compatible endpoints close the HTTP stream
+            // without a trailing newline on the last SSE frame. Appending one
+            // synthetic newline flushes the final buffered `data:` line so tool
+            // JSON is not truncated at EOF.
+            .chain(futures::stream::once(async {
+                Ok::<_, reqwest::Error>("\n".into())
+            }))
             .map(move |chunk| -> Result<Vec<StreamChunk>> {
                 let chunk = chunk.map_err(|e| LlmError::NetworkError(e.to_string()))?;
                 let text = String::from_utf8_lossy(&chunk);
@@ -1125,122 +1303,120 @@ impl LLMProvider for AnthropicProvider {
 
                 let mut chunks: Vec<StreamChunk> = Vec::new();
 
-                while let Some(newline_idx) = line_buffer.find('\n') {
-                    let line = line_buffer[..newline_idx].trim().to_string();
-                    line_buffer.drain(..=newline_idx);
-
-                    // Skip empty lines and SSE comment lines (':')
-                    if line.is_empty() || line.starts_with(':') {
-                        continue;
-                    }
-
-                    if let Some(data) = line.strip_prefix("data: ") {
-                        if let Ok(event) = serde_json::from_str::<StreamEvent>(data) {
-                            match event {
-                                StreamEvent::MessageStart { message } => {
-                                    prompt_tokens = message.usage.input_tokens as usize;
-                                    cache_hit_tokens =
-                                        message.usage.cache_read_input_tokens.map(|t| t as usize);
-                                    latest_output_tokens = message.usage.output_tokens as usize;
+                for data in drain_sse_data_lines(&mut line_buffer) {
+                    if let Ok(event) = serde_json::from_str::<StreamEvent>(&data) {
+                        match event {
+                            StreamEvent::MessageStart { message } => {
+                                prompt_tokens = message.usage.input_tokens as usize;
+                                cache_hit_tokens =
+                                    message.usage.cache_read_input_tokens.map(|t| t as usize);
+                                cache_write_tokens_stream = message
+                                    .usage
+                                    .cache_creation_input_tokens
+                                    .map(|t| t as usize);
+                                latest_output_tokens = message.usage.output_tokens as usize;
+                            }
+                            StreamEvent::ContentBlockStart {
+                                index,
+                                content_block,
+                            } if content_block.content_type == "tool_use" => {
+                                if let (Some(id), Some(name)) =
+                                    (content_block.id, content_block.name)
+                                {
+                                    // Signal start of a new tool call with its id and name.
+                                    chunks.push(StreamChunk::ToolCallDelta {
+                                        index,
+                                        id: Some(id),
+                                        function_name: Some(name),
+                                        function_arguments: None,
+                                        thought_signature: None,
+                                    });
                                 }
-                                StreamEvent::ContentBlockStart {
-                                    index,
-                                    content_block,
-                                } if content_block.content_type == "tool_use" => {
-                                    if let (Some(id), Some(name)) =
-                                        (content_block.id, content_block.name)
-                                    {
-                                        // Signal start of a new tool call with its id and name.
-                                        chunks.push(StreamChunk::ToolCallDelta {
-                                            index,
-                                            id: Some(id),
-                                            function_name: Some(name),
-                                            function_arguments: None,
-                                            thought_signature: None,
-                                        });
-                                    }
-                                }
-                                StreamEvent::ContentBlockDelta { index, delta } => {
-                                    match delta.delta_type.as_str() {
-                                        "text_delta" => {
-                                            if let Some(text) = delta.text {
-                                                chunks.push(StreamChunk::Content(text));
-                                            }
+                            }
+                            StreamEvent::ContentBlockDelta { index, delta } => {
+                                match delta.delta_type.as_str() {
+                                    "text_delta" => {
+                                        if let Some(text) = delta.text {
+                                            chunks.push(StreamChunk::Content(text));
                                         }
-                                        "input_json_delta" => {
-                                            if let Some(json) = delta.partial_json {
-                                                chunks.push(StreamChunk::ToolCallDelta {
-                                                    index,
-                                                    id: None,
-                                                    function_name: None,
-                                                    function_arguments: Some(json),
-                                                    thought_signature: None,
-                                                });
-                                            }
-                                        }
-                                        // Extended thinking streaming (OODA-03)
-                                        "thinking_delta" => {
-                                            if let Some(thinking) = delta.thinking {
-                                                chunks.push(StreamChunk::ThinkingContent {
-                                                    text: thinking,
-                                                    tokens_used: None,
-                                                    budget_total: None,
-                                                });
-                                            }
-                                        }
-                                        // signature_delta is informational; no StreamChunk needed
-                                        _ => {}
                                     }
-                                }
-                                StreamEvent::ContentBlockStop { .. } => {
-                                    // Block closed — consumer accumulates via deltas above
-                                }
-                                StreamEvent::MessageDelta { delta, usage } => {
-                                    if let Some(usage) = usage {
-                                        latest_output_tokens = usage.output_tokens as usize;
-                                    }
-                                    // Emit Finished with the authoritative stop_reason from
-                                    // message_delta.  Do NOT also emit from MessageStop to
-                                    // avoid duplicate Finished chunks.
-                                    if let Some(reason) = delta.stop_reason {
-                                        if !finished_emitted {
-                                            finished_emitted = true;
-                                            let mut usage = StreamUsage::new(
-                                                prompt_tokens,
-                                                latest_output_tokens,
-                                            );
-                                            if let Some(tokens) = cache_hit_tokens {
-                                                usage = usage.with_cache_hit_tokens(tokens);
-                                            }
-                                            chunks.push(StreamChunk::Finished {
-                                                reason,
-                                                ttft_ms: None,
-                                                usage: Some(usage),
+                                    "input_json_delta" => {
+                                        if let Some(json) = delta.partial_json {
+                                            chunks.push(StreamChunk::ToolCallDelta {
+                                                index,
+                                                id: None,
+                                                function_name: None,
+                                                function_arguments: Some(json),
+                                                thought_signature: None,
                                             });
                                         }
                                     }
-                                }
-                                StreamEvent::MessageStop if !finished_emitted => {
-                                    // message_stop arrives after message_delta which already
-                                    // emitted Finished.  Only emit here if message_delta
-                                    // did not carry a stop_reason (error recovery path).
-                                    finished_emitted = true;
-                                    let mut usage =
-                                        StreamUsage::new(prompt_tokens, latest_output_tokens);
-                                    if let Some(tokens) = cache_hit_tokens {
-                                        usage = usage.with_cache_hit_tokens(tokens);
+                                    // Extended thinking streaming (OODA-03)
+                                    "thinking_delta" => {
+                                        if let Some(thinking) = delta.thinking {
+                                            chunks.push(StreamChunk::ThinkingContent {
+                                                text: thinking,
+                                                tokens_used: None,
+                                                budget_total: None,
+                                            });
+                                        }
                                     }
-                                    chunks.push(StreamChunk::Finished {
-                                        reason: "stop".to_string(),
-                                        ttft_ms: None,
-                                        usage: Some(usage),
-                                    });
+                                    // signature_delta is informational; no StreamChunk needed
+                                    _ => {}
                                 }
-                                StreamEvent::Error { error } => {
-                                    return Err(LlmError::ApiError(error.message));
-                                }
-                                _ => {}
                             }
+                            StreamEvent::ContentBlockStop { .. } => {
+                                // Block closed — consumer accumulates via deltas above
+                            }
+                            StreamEvent::MessageDelta { delta, usage } => {
+                                if let Some(usage) = usage {
+                                    latest_output_tokens = usage.output_tokens as usize;
+                                }
+                                // Emit Finished with the authoritative stop_reason from
+                                // message_delta.  Do NOT also emit from MessageStop to
+                                // avoid duplicate Finished chunks.
+                                if let Some(reason) = delta.stop_reason {
+                                    if !finished_emitted {
+                                        finished_emitted = true;
+                                        let mut usage =
+                                            StreamUsage::new(prompt_tokens, latest_output_tokens);
+                                        if let Some(tokens) = cache_hit_tokens {
+                                            usage = usage.with_cache_hit_tokens(tokens);
+                                        }
+                                        if let Some(tokens) = cache_write_tokens_stream {
+                                            usage = usage.with_cache_write_tokens(tokens);
+                                        }
+                                        chunks.push(StreamChunk::Finished {
+                                            reason,
+                                            ttft_ms: None,
+                                            usage: Some(usage),
+                                        });
+                                    }
+                                }
+                            }
+                            StreamEvent::MessageStop if !finished_emitted => {
+                                // message_stop arrives after message_delta which already
+                                // emitted Finished.  Only emit here if message_delta
+                                // did not carry a stop_reason (error recovery path).
+                                finished_emitted = true;
+                                let mut usage =
+                                    StreamUsage::new(prompt_tokens, latest_output_tokens);
+                                if let Some(tokens) = cache_hit_tokens {
+                                    usage = usage.with_cache_hit_tokens(tokens);
+                                }
+                                if let Some(tokens) = cache_write_tokens_stream {
+                                    usage = usage.with_cache_write_tokens(tokens);
+                                }
+                                chunks.push(StreamChunk::Finished {
+                                    reason: "stop".to_string(),
+                                    ttft_ms: None,
+                                    usage: Some(usage),
+                                });
+                            }
+                            StreamEvent::Error { error } => {
+                                return Err(LlmError::ApiError(error.message));
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -1365,7 +1541,7 @@ mod tests {
                         "location": {"type": "string"}
                     }
                 }),
-                strict: None,
+                strict: Some(true),
             },
         }];
 
@@ -1377,6 +1553,184 @@ mod tests {
             anthropic_tools[0].description,
             "Get the weather for a location"
         );
+        assert_eq!(anthropic_tools[0].strict, Some(true));
+        assert_eq!(
+            anthropic_tools[0].input_schema["additionalProperties"],
+            serde_json::json!(false)
+        );
+    }
+
+    #[test]
+    fn test_convert_tools_strips_strict_when_budget_exceeded() {
+        use crate::traits::FunctionDefinition;
+
+        // Create 5 tools, each with 6 optional params = 30 total (> 24 limit)
+        let tools: Vec<ToolDefinition> = (0..5)
+            .map(|i| ToolDefinition {
+                tool_type: "function".to_string(),
+                function: FunctionDefinition {
+                    name: format!("tool_{i}"),
+                    description: format!("Tool {i}"),
+                    parameters: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "string"},
+                            "b": {"type": "string"},
+                            "c": {"type": "string"},
+                            "d": {"type": "string"},
+                            "e": {"type": "string"},
+                            "f": {"type": "string"}
+                        },
+                        "required": []
+                    }),
+                    strict: Some(true),
+                },
+            })
+            .collect();
+
+        let result = AnthropicProvider::convert_tools(&tools);
+
+        // All 5 tools should have strict stripped (set to None)
+        for tool in &result {
+            assert_eq!(
+                tool.strict, None,
+                "strict should be None when budget exceeded for tool {}",
+                tool.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_convert_tools_preserves_strict_within_budget() {
+        use crate::traits::FunctionDefinition;
+
+        // Single tool with 1 optional param — well within the 24-param budget
+        let tools = vec![ToolDefinition {
+            tool_type: "function".to_string(),
+            function: FunctionDefinition {
+                name: "small_tool".to_string(),
+                description: "A small tool".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "required_param": {"type": "string"},
+                        "optional_param": {"type": "string"}
+                    },
+                    "required": ["required_param"]
+                }),
+                strict: Some(true),
+            },
+        }];
+
+        let result = AnthropicProvider::convert_tools(&tools);
+        assert_eq!(result[0].strict, Some(true));
+    }
+
+    #[test]
+    fn test_convert_tools_strips_strict_when_too_many_strict_tools() {
+        use crate::traits::FunctionDefinition;
+
+        // Create 25 tools (> 20 limit), each with 0 optional params
+        let tools: Vec<ToolDefinition> = (0..25)
+            .map(|i| ToolDefinition {
+                tool_type: "function".to_string(),
+                function: FunctionDefinition {
+                    name: format!("tool_{i}"),
+                    description: format!("Tool {i}"),
+                    parameters: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "string"}
+                        },
+                        "required": ["a"]
+                    }),
+                    strict: Some(true),
+                },
+            })
+            .collect();
+
+        let result = AnthropicProvider::convert_tools(&tools);
+        for tool in &result {
+            assert_eq!(tool.strict, None);
+        }
+    }
+
+    #[test]
+    fn test_sanitize_parameters_adds_additional_properties_false_recursively() {
+        let sanitized = sanitize_parameters(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "filters": {
+                    "type": "object",
+                    "properties": {
+                        "region": { "type": "string" }
+                    }
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        }));
+
+        assert_eq!(sanitized["additionalProperties"], serde_json::json!(false));
+        assert_eq!(
+            sanitized["properties"]["filters"]["additionalProperties"],
+            serde_json::json!(false)
+        );
+        assert_eq!(
+            sanitized["properties"]["items"]["items"]["additionalProperties"],
+            serde_json::json!(false)
+        );
+    }
+
+    #[test]
+    fn test_sanitize_parameters_removes_unsupported_constraints_and_preserves_them_in_description()
+    {
+        let sanitized = sanitize_parameters(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "choices": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "maxItems": 4,
+                    "description": "Selectable choices"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50
+                }
+            }
+        }));
+
+        assert!(sanitized["properties"]["choices"].get("maxItems").is_none());
+        assert_eq!(
+            sanitized["properties"]["choices"]["description"],
+            serde_json::json!("Selectable choices Constraints: maxItems: at most 4 items")
+        );
+        assert!(sanitized["properties"]["limit"].get("minimum").is_none());
+        assert!(sanitized["properties"]["limit"].get("maximum").is_none());
+        assert_eq!(
+            sanitized["properties"]["limit"]["description"],
+            serde_json::json!("Constraints: minimum: >= 1 maximum: <= 50")
+        );
+    }
+
+    #[test]
+    fn test_sanitize_parameters_preserves_existing_additional_properties() {
+        let sanitized = sanitize_parameters(serde_json::json!({
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {}
+        }));
+
+        assert_eq!(sanitized["additionalProperties"], serde_json::json!(true));
     }
 
     #[test]
@@ -2133,22 +2487,47 @@ mod tests {
 
         let mut buffer = String::new();
         buffer.push_str(chunk1);
-        // After chunk1: no complete line yet, nothing extracted
-        assert!(buffer.find('\n').is_none());
+        assert!(drain_sse_data_lines(&mut buffer).is_empty());
 
         buffer.push_str(chunk2);
-        // After chunk2: one complete line available
-        let newline_idx = buffer.find('\n').unwrap();
-        let line = buffer[..newline_idx].trim().to_string();
-        buffer.drain(..=newline_idx);
+        let data_lines = drain_sse_data_lines(&mut buffer);
+        assert_eq!(data_lines.len(), 1);
 
-        // Parse the complete line
-        let data = line.strip_prefix("data: ").unwrap();
-        let event: StreamEvent = serde_json::from_str(data).unwrap();
+        let event: StreamEvent = serde_json::from_str(&data_lines[0]).unwrap();
         match event {
             StreamEvent::ContentBlockDelta { delta, .. } => {
                 assert_eq!(delta.delta_type, "text_delta");
                 assert_eq!(delta.text, Some("hello".to_string()));
+            }
+            _ => panic!("Expected ContentBlockDelta"),
+        }
+    }
+
+    #[test]
+    fn test_sse_line_buffer_flushes_unterminated_final_data_line() {
+        // Root-cause regression: some Anthropic-compatible endpoints end the
+        // stream without a trailing newline on the final `data:` event.
+        let mut buffer = String::from(
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"audit.md\\\"}\"}}",
+        );
+
+        // Before EOF flush, nothing is emitted because the line is still unterminated.
+        assert!(drain_sse_data_lines(&mut buffer).is_empty());
+
+        // Simulate the synthetic newline appended at EOF.
+        buffer.push('\n');
+        let data_lines = drain_sse_data_lines(&mut buffer);
+        assert_eq!(data_lines.len(), 1);
+
+        let event: StreamEvent = serde_json::from_str(&data_lines[0]).unwrap();
+        match event {
+            StreamEvent::ContentBlockDelta { index, delta } => {
+                assert_eq!(index, 1);
+                assert_eq!(delta.delta_type, "input_json_delta");
+                assert_eq!(
+                    delta.partial_json,
+                    Some("{\"path\":\"audit.md\"}".to_string())
+                );
             }
             _ => panic!("Expected ContentBlockDelta"),
         }
@@ -2161,20 +2540,87 @@ mod tests {
         let mut buffer = String::new();
         buffer.push_str(chunk);
 
-        let mut events: Vec<StreamEvent> = Vec::new();
-        while let Some(newline_idx) = buffer.find('\n') {
-            let line = buffer[..newline_idx].trim().to_string();
-            buffer.drain(..=newline_idx);
-            if let Some(data) = line.strip_prefix("data: ") {
-                if let Ok(event) = serde_json::from_str::<StreamEvent>(data) {
-                    events.push(event);
-                }
-            }
-        }
+        let events: Vec<StreamEvent> = drain_sse_data_lines(&mut buffer)
+            .into_iter()
+            .map(|data| serde_json::from_str::<StreamEvent>(&data).unwrap())
+            .collect();
 
         assert_eq!(events.len(), 2);
         assert!(matches!(events[0], StreamEvent::Ping));
         assert!(matches!(events[1], StreamEvent::MessageStop));
+    }
+
+    #[tokio::test]
+    async fn test_chat_with_tools_stream_flushes_final_unterminated_tool_delta() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request_buf = [0u8; 4096];
+            let _ = socket.read(&mut request_buf).await.unwrap();
+
+            let response = concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "content-type: text/event-stream\r\n",
+                "cache-control: no-cache\r\n",
+                "connection: close\r\n\r\n",
+                "event: message_start\n",
+                "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-haiku-4-5\",\"stop_reason\":null,\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n\n",
+                "event: content_block_start\n",
+                "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"write_file\",\"input\":{}}}\n\n",
+                "event: content_block_delta\n",
+                "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"audit.md\\\",\\\"content\\\":\\\"OK\\\"}\"}}"
+            );
+
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let provider = AnthropicProvider::new("test-key")
+            .with_base_url(format!("http://{}", addr))
+            .with_model("claude-haiku-4-5");
+        let messages = vec![ChatMessage::user("Write the audit file.")];
+
+        let stream = provider
+            .chat_with_tools_stream(&messages, &[], None, None)
+            .await
+            .unwrap();
+        let chunks: Vec<StreamChunk> = stream.map(|item| item.unwrap()).collect().await;
+        server.await.unwrap();
+
+        let mut saw_tool_start = false;
+        let mut combined_arguments = String::new();
+
+        for chunk in chunks {
+            if let StreamChunk::ToolCallDelta {
+                id,
+                function_name,
+                function_arguments,
+                ..
+            } = chunk
+            {
+                if id.as_deref() == Some("toolu_1")
+                    && function_name.as_deref() == Some("write_file")
+                {
+                    saw_tool_start = true;
+                }
+                if let Some(fragment) = function_arguments {
+                    combined_arguments.push_str(&fragment);
+                }
+            }
+        }
+
+        assert!(
+            saw_tool_start,
+            "expected streamed tool call start to be preserved"
+        );
+        assert_eq!(
+            combined_arguments,
+            "{\"path\":\"audit.md\",\"content\":\"OK\"}"
+        );
     }
 
     #[test]

--- a/src/providers/azure_openai.rs
+++ b/src/providers/azure_openai.rs
@@ -560,6 +560,7 @@ impl LLMProvider for AzureOpenAIProvider {
             tool_calls: Vec::new(),
             metadata,
             cache_hit_tokens: cache_hit,
+            cache_write_tokens: None,
             thinking_tokens: thinking,
             thinking_content: None,
         })
@@ -734,6 +735,7 @@ impl LLMProvider for AzureOpenAIProvider {
             tool_calls,
             metadata,
             cache_hit_tokens: cache_hit,
+            cache_write_tokens: None,
             thinking_tokens: thinking,
             thinking_content: None,
         })

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -1117,7 +1117,23 @@ impl BedrockProvider {
 
         let mut bedrock_tools = Vec::new();
         for tool in tools {
-            let schema_doc = Self::json_to_document(&tool.function.parameters);
+            // Bedrock uses Claude under the hood — apply the same schema
+            // sanitization as the Anthropic provider: strip unsupported
+            // constraint keywords and ensure additionalProperties: false.
+            let sanitized_params = super::schema_utils::ensure_additional_properties_false(
+                super::schema_utils::strip_keys_recursive(
+                    tool.function.parameters.clone(),
+                    &[
+                        "minimum",
+                        "maximum",
+                        "minLength",
+                        "maxLength",
+                        "minItems",
+                        "maxItems",
+                    ],
+                ),
+            );
+            let schema_doc = Self::json_to_document(&sanitized_params);
             let tool_name =
                 Self::resolve_bedrock_tool_name(&tool.function.name, Some(tool_name_aliases));
 
@@ -1315,6 +1331,7 @@ impl BedrockProvider {
             tool_calls,
             metadata: HashMap::new(),
             cache_hit_tokens: None,
+            cache_write_tokens: None,
             thinking_tokens: None,
             thinking_content,
         })

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -1477,25 +1477,73 @@ impl GeminiProvider {
     // OODA-06: Tool Conversion Methods
     // =========================================================================
 
-    /// Remove `$schema` field from JSON object (Gemini doesn't accept it)
-    fn sanitize_parameters(mut params: serde_json::Value) -> serde_json::Value {
-        if let Some(obj) = params.as_object_mut() {
-            obj.remove("$schema");
+    /// Normalize JSON Schema into Gemini's narrower function-declaration subset.
+    ///
+    /// WHY: EdgeCrab tool schemas target OpenAI/Anthropic strict mode, which
+    /// allows constructs Gemini's native Schema proto does not. Gemini function
+    /// declarations support a smaller OpenAPI-style schema where `type` is a
+    /// single string and nullability is expressed as `nullable: true`.
+    fn sanitize_parameters(params: serde_json::Value) -> serde_json::Value {
+        match params {
+            serde_json::Value::Object(mut obj) => {
+                obj.remove("$schema");
+                obj.remove("strict");
+                obj.remove("additionalProperties");
+                obj.remove("anyOf");
+                obj.remove("oneOf");
+                obj.remove("allOf");
+                obj.remove("not");
+                obj.remove("if");
+                obj.remove("then");
+                obj.remove("else");
+                obj.remove("dependentRequired");
+                obj.remove("dependentSchemas");
+                obj.remove("unevaluatedProperties");
+                obj.remove("patternProperties");
+                obj.remove("propertyNames");
 
-            // Also sanitize nested objects in properties, items, etc.
-            for (_key, value) in obj.iter_mut() {
-                if value.is_object() || value.is_array() {
-                    *value = Self::sanitize_parameters(value.clone());
+                if let Some(type_value) = obj.get("type").cloned() {
+                    match type_value {
+                        serde_json::Value::Array(types) => {
+                            let mut nullable = false;
+                            let mut non_null_types = Vec::new();
+
+                            for entry in types {
+                                match entry {
+                                    serde_json::Value::String(s) if s == "null" => nullable = true,
+                                    serde_json::Value::String(s) => non_null_types.push(s),
+                                    _ => {}
+                                }
+                            }
+
+                            if let Some(primary) = non_null_types.into_iter().next() {
+                                obj.insert("type".into(), serde_json::Value::String(primary));
+                                if nullable {
+                                    obj.insert("nullable".into(), serde_json::Value::Bool(true));
+                                }
+                            } else {
+                                obj.remove("type");
+                            }
+                        }
+                        serde_json::Value::String(_) => {}
+                        _ => {
+                            obj.remove("type");
+                        }
+                    }
                 }
+
+                let sanitized = obj
+                    .into_iter()
+                    .map(|(key, value)| (key, Self::sanitize_parameters(value)))
+                    .collect::<serde_json::Map<String, serde_json::Value>>();
+
+                serde_json::Value::Object(sanitized)
             }
-        } else if let Some(arr) = params.as_array_mut() {
-            for item in arr.iter_mut() {
-                if item.is_object() || item.is_array() {
-                    *item = Self::sanitize_parameters(item.clone());
-                }
-            }
+            serde_json::Value::Array(values) => serde_json::Value::Array(
+                values.into_iter().map(Self::sanitize_parameters).collect(),
+            ),
+            other => other,
         }
-        params
     }
 
     /// Convert EdgeCode ToolDefinition to Gemini FunctionDeclaration format
@@ -1814,6 +1862,7 @@ impl LLMProvider for GeminiProvider {
             } else {
                 None
             },
+            cache_write_tokens: None,
             // OODA-25: Track thinking tokens and content from Gemini 2.5+/3.x
             thinking_tokens: if usage.thoughts_token_count > 0 {
                 Some(usage.thoughts_token_count)
@@ -1977,6 +2026,7 @@ impl LLMProvider for GeminiProvider {
             } else {
                 None
             },
+            cache_write_tokens: None,
             // OODA-25: Track thinking tokens and content from Gemini 2.5+/3.x
             thinking_tokens: if usage.thoughts_token_count > 0 {
                 Some(usage.thoughts_token_count)
@@ -2549,6 +2599,7 @@ impl GeminiProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_context_length_detection() {
@@ -2628,6 +2679,96 @@ mod tests {
         let provider = GeminiProvider::new("test-key");
         assert_eq!(EmbeddingProvider::model(&provider), "gemini-embedding-001");
         assert_eq!(provider.dimension(), 3072);
+    }
+
+    #[test]
+    fn test_sanitize_parameters_converts_nullable_type_array() {
+        let sanitized = GeminiProvider::sanitize_parameters(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "content": {
+                    "type": ["string", "null"],
+                    "description": "Nullable content"
+                },
+                "count": {
+                    "type": "integer"
+                }
+            },
+            "required": ["content", "count"]
+        }));
+
+        assert_eq!(sanitized["type"], "object");
+        assert!(sanitized.get("additionalProperties").is_none());
+        assert_eq!(sanitized["properties"]["content"]["type"], "string");
+        assert_eq!(sanitized["properties"]["content"]["nullable"], true);
+        assert_eq!(sanitized["properties"]["count"]["type"], "integer");
+        assert!(sanitized["properties"]["count"].get("nullable").is_none());
+    }
+
+    #[test]
+    fn test_sanitize_parameters_strips_gemini_unsupported_keywords() {
+        let sanitized = GeminiProvider::sanitize_parameters(json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "strict": true,
+            "oneOf": [{"type": "string"}],
+            "properties": {
+                "patch": {
+                    "type": ["string", "null"],
+                    "anyOf": [{"type": "string"}],
+                    "allOf": [{"minLength": 1}],
+                    "if": {"type": "string"},
+                    "then": {"minLength": 2},
+                    "else": {"maxLength": 0},
+                    "dependentRequired": {"foo": ["bar"]},
+                    "patternProperties": {".*": {"type": "string"}}
+                }
+            }
+        }));
+
+        assert!(sanitized.get("$schema").is_none());
+        assert!(sanitized.get("strict").is_none());
+        assert!(sanitized.get("oneOf").is_none());
+        let patch = &sanitized["properties"]["patch"];
+        assert_eq!(patch["type"], "string");
+        assert_eq!(patch["nullable"], true);
+        assert!(patch.get("anyOf").is_none());
+        assert!(patch.get("allOf").is_none());
+        assert!(patch.get("if").is_none());
+        assert!(patch.get("then").is_none());
+        assert!(patch.get("else").is_none());
+        assert!(patch.get("dependentRequired").is_none());
+        assert!(patch.get("patternProperties").is_none());
+    }
+
+    #[test]
+    fn test_convert_tools_uses_sanitized_gemini_parameters() {
+        let tools = vec![ToolDefinition::function(
+            "write_file",
+            "Write a file",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "content": {
+                        "type": ["string", "null"],
+                        "description": "Optional scaffold content"
+                    }
+                },
+                "required": ["content"]
+            }),
+        )];
+
+        let converted = GeminiProvider::convert_tools(&tools);
+        let params = converted[0].function_declarations[0]
+            .parameters
+            .as_ref()
+            .expect("parameters should be present");
+
+        assert!(params.get("additionalProperties").is_none());
+        assert_eq!(params["properties"]["content"]["type"], "string");
+        assert_eq!(params["properties"]["content"]["nullable"], true);
     }
 
     #[test]

--- a/src/providers/genai_events.rs
+++ b/src/providers/genai_events.rs
@@ -443,6 +443,7 @@ mod tests {
             finish_reason: Some("stop".to_string()),
             metadata: Default::default(),
             cache_hit_tokens: None,
+            cache_write_tokens: None,
             tool_calls: vec![],
             thinking_tokens: None,
             thinking_content: None,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,5 +1,7 @@
 //! LLM provider implementations.
 
+pub mod schema_utils;
+
 pub mod openai;
 
 pub mod mock;

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -495,6 +495,7 @@ impl LLMProvider for OpenAIProvider {
             tool_calls: Vec::new(),
             metadata,
             cache_hit_tokens,
+            cache_write_tokens: None,
             thinking_tokens,
             thinking_content: None,
         })
@@ -636,6 +637,7 @@ impl LLMProvider for OpenAIProvider {
             tool_calls,
             metadata,
             cache_hit_tokens,
+            cache_write_tokens: None,
             thinking_tokens,
             thinking_content: None,
         })

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -691,6 +691,7 @@ impl OpenRouterProvider {
             finish_reason: choice.finish_reason.clone(),
             metadata: HashMap::new(),
             cache_hit_tokens: None,
+            cache_write_tokens: None,
             thinking_tokens: None,
             thinking_content: None,
         })

--- a/src/providers/schema_utils.rs
+++ b/src/providers/schema_utils.rs
@@ -1,0 +1,652 @@
+//! Shared JSON Schema utilities for provider-specific sanitization.
+//!
+//! Each LLM provider imposes its own subset of JSON Schema.  This module
+//! provides reusable, composable helpers so that per-provider `sanitize_*`
+//! and `convert_tools` methods stay DRY while each provider retains full
+//! control over *which* transformations to apply (Open/Closed Principle).
+//!
+//! # Design
+//!
+//! * **Pure functions** — every helper takes a `serde_json::Value` and returns
+//!   a new `serde_json::Value`.  No provider state, no side-effects.
+//! * **Composable** — providers chain the helpers they need in their own
+//!   `sanitize_parameters()` or `convert_tools()` methods.
+//! * **Tested** — unit tests cover each helper in isolation.
+
+use serde_json::Value;
+
+// ============================================================================
+// Schema Analysis
+// ============================================================================
+
+/// Count the total number of optional parameters across a set of tool schemas.
+///
+/// A parameter is "optional" if it appears in `properties` but NOT in
+/// `required`.  This is the metric Anthropic enforces (limit: 24 across
+/// all strict tools combined).
+pub fn count_optional_params(schema: &Value) -> usize {
+    let obj = match schema.as_object() {
+        Some(o) => o,
+        None => return 0,
+    };
+
+    let properties = match obj.get("properties").and_then(|v| v.as_object()) {
+        Some(p) => p,
+        None => return 0,
+    };
+
+    let required: std::collections::HashSet<&str> = obj
+        .get("required")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    properties
+        .keys()
+        .filter(|k| !required.contains(k.as_str()))
+        .count()
+}
+
+/// Count parameters that use union types (`anyOf` or type arrays like
+/// `"type": ["string", "null"]`).
+///
+/// Anthropic limits this to 16 across all strict tools combined.
+pub fn count_union_type_params(schema: &Value) -> usize {
+    let obj = match schema.as_object() {
+        Some(o) => o,
+        None => return 0,
+    };
+
+    let properties = match obj.get("properties").and_then(|v| v.as_object()) {
+        Some(p) => p,
+        None => return 0,
+    };
+
+    properties
+        .values()
+        .filter(|prop| {
+            let prop_obj = match prop.as_object() {
+                Some(o) => o,
+                None => return false,
+            };
+            // Check for anyOf
+            if prop_obj.contains_key("anyOf") {
+                return true;
+            }
+            // Check for type array: "type": ["string", "null"]
+            if let Some(Value::Array(_)) = prop_obj.get("type") {
+                return true;
+            }
+            false
+        })
+        .count()
+}
+
+// ============================================================================
+// Anthropic Strict-Mode Budget
+// ============================================================================
+
+/// Anthropic strict-mode limits (from official docs at
+/// platform.claude.com/docs/en/build-with-claude/structured-outputs).
+pub const ANTHROPIC_MAX_STRICT_TOOLS: usize = 20;
+pub const ANTHROPIC_MAX_OPTIONAL_PARAMS: usize = 24;
+pub const ANTHROPIC_MAX_UNION_TYPE_PARAMS: usize = 16;
+
+/// Result of checking strict-mode budget across a set of tool schemas.
+#[derive(Debug, Clone)]
+pub struct StrictBudgetCheck {
+    pub total_strict_tools: usize,
+    pub total_optional_params: usize,
+    pub total_union_type_params: usize,
+    pub exceeds_limits: bool,
+}
+
+/// Check whether a set of tools would exceed Anthropic's strict-mode budget.
+///
+/// Takes an iterator of `(is_strict, &schema)` pairs.
+pub fn check_anthropic_strict_budget<'a>(
+    tools: impl Iterator<Item = (bool, &'a Value)>,
+) -> StrictBudgetCheck {
+    let mut total_strict_tools = 0usize;
+    let mut total_optional_params = 0usize;
+    let mut total_union_type_params = 0usize;
+
+    for (is_strict, schema) in tools {
+        if is_strict {
+            total_strict_tools += 1;
+            total_optional_params += count_optional_params(schema);
+            total_union_type_params += count_union_type_params(schema);
+        }
+    }
+
+    let exceeds_limits = total_strict_tools > ANTHROPIC_MAX_STRICT_TOOLS
+        || total_optional_params > ANTHROPIC_MAX_OPTIONAL_PARAMS
+        || total_union_type_params > ANTHROPIC_MAX_UNION_TYPE_PARAMS;
+
+    StrictBudgetCheck {
+        total_strict_tools,
+        total_optional_params,
+        total_union_type_params,
+        exceeds_limits,
+    }
+}
+
+// ============================================================================
+// Schema Transformations (composable building blocks)
+// ============================================================================
+
+/// Recursively strip a set of keys from a JSON Schema.
+///
+/// Used by providers that don't support certain JSON Schema keywords
+/// (e.g., Gemini strips `$schema`, `strict`, `additionalProperties`).
+pub fn strip_keys_recursive(value: Value, keys: &[&str]) -> Value {
+    match value {
+        Value::Object(mut obj) => {
+            for key in keys {
+                obj.remove(*key);
+            }
+            let sanitized = obj
+                .into_iter()
+                .map(|(k, v)| (k, strip_keys_recursive(v, keys)))
+                .collect();
+            Value::Object(sanitized)
+        }
+        Value::Array(arr) => Value::Array(
+            arr.into_iter()
+                .map(|v| strip_keys_recursive(v, keys))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+/// Recursively add `"additionalProperties": false` to every object-typed
+/// schema node that doesn't already have it set.
+///
+/// Required by both OpenAI strict mode and Anthropic strict mode.
+pub fn ensure_additional_properties_false(value: Value) -> Value {
+    match value {
+        Value::Object(mut obj) => {
+            // Check if this node is an object type
+            let is_object_type = obj
+                .get("type")
+                .map(|t| match t {
+                    Value::String(s) => s == "object",
+                    Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some("object")),
+                    _ => false,
+                })
+                .unwrap_or(false);
+
+            if is_object_type && !obj.contains_key("additionalProperties") {
+                obj.insert("additionalProperties".into(), Value::Bool(false));
+            }
+
+            let sanitized = obj
+                .into_iter()
+                .map(|(k, v)| (k, ensure_additional_properties_false(v)))
+                .collect();
+            Value::Object(sanitized)
+        }
+        Value::Array(arr) => Value::Array(
+            arr.into_iter()
+                .map(ensure_additional_properties_false)
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+/// Convert type arrays like `"type": ["string", "null"]` to single type +
+/// `"nullable": true`.
+///
+/// Gemini's function-declaration schema requires a single string `type`
+/// field and uses `nullable: true` instead of union types.
+pub fn convert_type_arrays_to_nullable(value: Value) -> Value {
+    match value {
+        Value::Object(mut obj) => {
+            if let Some(Value::Array(types)) = obj.get("type").cloned() {
+                let mut nullable = false;
+                let mut non_null_types = Vec::new();
+
+                for entry in types {
+                    match entry {
+                        Value::String(s) if s == "null" => nullable = true,
+                        Value::String(s) => non_null_types.push(s),
+                        _ => {}
+                    }
+                }
+
+                if let Some(primary) = non_null_types.into_iter().next() {
+                    obj.insert("type".into(), Value::String(primary));
+                    if nullable {
+                        obj.insert("nullable".into(), Value::Bool(true));
+                    }
+                } else {
+                    obj.remove("type");
+                }
+            }
+
+            let sanitized = obj
+                .into_iter()
+                .map(|(k, v)| (k, convert_type_arrays_to_nullable(v)))
+                .collect();
+            Value::Object(sanitized)
+        }
+        Value::Array(arr) => Value::Array(
+            arr.into_iter()
+                .map(convert_type_arrays_to_nullable)
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+// ============================================================================
+// OpenAI Strict-Mode Schema Normalization
+// ============================================================================
+
+/// Normalize a schema for OpenAI strict mode:
+/// - All properties must be listed in `required`
+/// - `additionalProperties: false` on every object
+/// - Optional params get `"type": ["original_type", "null"]`
+///
+/// This follows the OpenAI docs: "You can denote optional fields by adding
+/// `null` as a type option."
+pub fn normalize_for_openai_strict(value: Value) -> Value {
+    match value {
+        Value::Object(mut obj) => {
+            let is_object_type = obj
+                .get("type")
+                .map(|t| matches!(t, Value::String(s) if s == "object"))
+                .unwrap_or(false);
+
+            if is_object_type {
+                // Ensure additionalProperties: false
+                if !obj.contains_key("additionalProperties") {
+                    obj.insert("additionalProperties".into(), Value::Bool(false));
+                }
+
+                // Make all properties required, adding null to type for optional ones
+                if let Some(properties) = obj.get("properties").cloned() {
+                    if let Some(props_obj) = properties.as_object() {
+                        let required: std::collections::HashSet<String> = obj
+                            .get("required")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+
+                        let all_keys: Vec<String> = props_obj.keys().cloned().collect();
+
+                        // For previously-optional params, add null to type union
+                        let mut new_props = props_obj.clone();
+                        for key in &all_keys {
+                            if !required.contains(key) {
+                                if let Some(prop) = new_props.get_mut(key) {
+                                    make_nullable(prop);
+                                }
+                            }
+                        }
+                        obj.insert("properties".into(), Value::Object(new_props));
+
+                        // All keys are now required
+                        let all_required: Vec<Value> =
+                            all_keys.into_iter().map(Value::String).collect();
+                        obj.insert("required".into(), Value::Array(all_required));
+                    }
+                }
+            }
+
+            // Recurse into all values
+            let sanitized = obj
+                .into_iter()
+                .map(|(k, v)| (k, normalize_for_openai_strict(v)))
+                .collect();
+            Value::Object(sanitized)
+        }
+        Value::Array(arr) => {
+            Value::Array(arr.into_iter().map(normalize_for_openai_strict).collect())
+        }
+        other => other,
+    }
+}
+
+/// Make a property schema nullable by adding `"null"` to its type.
+///
+/// - `"type": "string"` → `"type": ["string", "null"]`
+/// - `"type": ["string", "integer"]` → `"type": ["string", "integer", "null"]`
+/// - Already has null → no change
+fn make_nullable(prop: &mut Value) {
+    if let Some(obj) = prop.as_object_mut() {
+        match obj.get("type").cloned() {
+            Some(Value::String(s)) => {
+                obj.insert(
+                    "type".into(),
+                    Value::Array(vec![Value::String(s), Value::String("null".into())]),
+                );
+            }
+            Some(Value::Array(mut arr)) => {
+                let has_null = arr.iter().any(|v| v.as_str() == Some("null"));
+                if !has_null {
+                    arr.push(Value::String("null".into()));
+                    obj.insert("type".into(), Value::Array(arr));
+                }
+            }
+            _ => {
+                // No type field or unexpected type — wrap in anyOf with null
+                // This is a defensive fallback
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ---- count_optional_params ----
+
+    #[test]
+    fn test_count_optional_params_all_required() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "integer"}
+            },
+            "required": ["a", "b"]
+        });
+        assert_eq!(count_optional_params(&schema), 0);
+    }
+
+    #[test]
+    fn test_count_optional_params_some_optional() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "integer"},
+                "c": {"type": "boolean"}
+            },
+            "required": ["a"]
+        });
+        assert_eq!(count_optional_params(&schema), 2);
+    }
+
+    #[test]
+    fn test_count_optional_params_no_required_array() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "integer"}
+            }
+        });
+        assert_eq!(count_optional_params(&schema), 2);
+    }
+
+    #[test]
+    fn test_count_optional_params_no_properties() {
+        let schema = json!({"type": "object"});
+        assert_eq!(count_optional_params(&schema), 0);
+    }
+
+    // ---- count_union_type_params ----
+
+    #[test]
+    fn test_count_union_type_params_with_anyof() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                "b": {"type": "string"}
+            }
+        });
+        assert_eq!(count_union_type_params(&schema), 1);
+    }
+
+    #[test]
+    fn test_count_union_type_params_with_type_array() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": ["string", "null"]},
+                "b": {"type": "string"}
+            }
+        });
+        assert_eq!(count_union_type_params(&schema), 1);
+    }
+
+    // ---- check_anthropic_strict_budget ----
+
+    #[test]
+    fn test_budget_within_limits() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"}
+            },
+            "required": ["a"]
+        });
+        let check = check_anthropic_strict_budget(vec![(true, &schema)].into_iter());
+        assert!(!check.exceeds_limits);
+        assert_eq!(check.total_strict_tools, 1);
+        assert_eq!(check.total_optional_params, 0);
+    }
+
+    #[test]
+    fn test_budget_exceeds_optional_params() {
+        // Create 5 tools each with 6 optional params = 30 total > 24 limit
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "string"},
+                "c": {"type": "string"},
+                "d": {"type": "string"},
+                "e": {"type": "string"},
+                "f": {"type": "string"}
+            },
+            "required": []
+        });
+        let tools: Vec<(bool, &Value)> = (0..5).map(|_| (true, &schema)).collect();
+        let check = check_anthropic_strict_budget(tools.into_iter());
+        assert!(check.exceeds_limits);
+        assert_eq!(check.total_optional_params, 30);
+    }
+
+    #[test]
+    fn test_budget_exceeds_tool_count() {
+        let schema = json!({"type": "object", "properties": {}, "required": []});
+        let tools: Vec<(bool, &Value)> = (0..25).map(|_| (true, &schema)).collect();
+        let check = check_anthropic_strict_budget(tools.into_iter());
+        assert!(check.exceeds_limits);
+        assert_eq!(check.total_strict_tools, 25);
+    }
+
+    #[test]
+    fn test_budget_non_strict_tools_ignored() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "string"}
+            }
+            // no required → 2 optional params each
+        });
+        // 50 tools but none strict → should be within limits
+        let tools: Vec<(bool, &Value)> = (0..50).map(|_| (false, &schema)).collect();
+        let check = check_anthropic_strict_budget(tools.into_iter());
+        assert!(!check.exceeds_limits);
+        assert_eq!(check.total_strict_tools, 0);
+        assert_eq!(check.total_optional_params, 0);
+    }
+
+    // ---- strip_keys_recursive ----
+
+    #[test]
+    fn test_strip_keys_recursive() {
+        let schema = json!({
+            "type": "object",
+            "strict": true,
+            "additionalProperties": false,
+            "properties": {
+                "a": {
+                    "type": "string",
+                    "strict": true,
+                    "additionalProperties": false
+                }
+            }
+        });
+        let result = strip_keys_recursive(schema, &["strict", "additionalProperties"]);
+        assert!(result.get("strict").is_none());
+        assert!(result.get("additionalProperties").is_none());
+        let a = &result["properties"]["a"];
+        assert!(a.get("strict").is_none());
+        assert!(a.get("additionalProperties").is_none());
+    }
+
+    // ---- ensure_additional_properties_false ----
+
+    #[test]
+    fn test_ensure_additional_properties_false() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let result = ensure_additional_properties_false(schema);
+        assert_eq!(result["additionalProperties"], false);
+        assert_eq!(
+            result["properties"]["nested"]["additionalProperties"],
+            false
+        );
+    }
+
+    #[test]
+    fn test_ensure_additional_properties_preserves_existing() {
+        let schema = json!({
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {}
+        });
+        let result = ensure_additional_properties_false(schema);
+        // Should preserve existing value
+        assert_eq!(result["additionalProperties"], true);
+    }
+
+    // ---- convert_type_arrays_to_nullable ----
+
+    #[test]
+    fn test_convert_type_arrays_to_nullable() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": ["string", "null"]}
+            }
+        });
+        let result = convert_type_arrays_to_nullable(schema);
+        assert_eq!(result["properties"]["a"]["type"], "string");
+        assert_eq!(result["properties"]["a"]["nullable"], true);
+    }
+
+    // ---- normalize_for_openai_strict ----
+
+    #[test]
+    fn test_normalize_for_openai_strict() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "required_param": {"type": "string"},
+                "optional_param": {"type": "integer"}
+            },
+            "required": ["required_param"]
+        });
+        let result = normalize_for_openai_strict(schema);
+
+        // All params should be required
+        let required = result["required"].as_array().unwrap();
+        assert!(required.contains(&json!("required_param")));
+        assert!(required.contains(&json!("optional_param")));
+
+        // optional_param should now be nullable
+        let opt_type = &result["properties"]["optional_param"]["type"];
+        assert!(opt_type.is_array());
+        let types = opt_type.as_array().unwrap();
+        assert!(types.contains(&json!("integer")));
+        assert!(types.contains(&json!("null")));
+
+        // required_param stays the same
+        assert_eq!(result["properties"]["required_param"]["type"], "string");
+
+        // additionalProperties added
+        assert_eq!(result["additionalProperties"], false);
+    }
+
+    #[test]
+    fn test_normalize_for_openai_strict_nested() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "value": {"type": "number"}
+                    },
+                    "required": ["name"]
+                }
+            },
+            "required": ["config"]
+        });
+        let result = normalize_for_openai_strict(schema);
+
+        // Nested object should also be normalized
+        let nested = &result["properties"]["config"];
+        assert_eq!(nested["additionalProperties"], false);
+        let nested_required = nested["required"].as_array().unwrap();
+        assert!(nested_required.contains(&json!("name")));
+        assert!(nested_required.contains(&json!("value")));
+    }
+
+    // ---- make_nullable ----
+
+    #[test]
+    fn test_make_nullable_string_type() {
+        let mut prop = json!({"type": "string", "description": "A name"});
+        make_nullable(&mut prop);
+        assert_eq!(prop["type"], json!(["string", "null"]));
+    }
+
+    #[test]
+    fn test_make_nullable_already_nullable() {
+        let mut prop = json!({"type": ["string", "null"]});
+        make_nullable(&mut prop);
+        // Should not add duplicate null
+        let types = prop["type"].as_array().unwrap();
+        assert_eq!(types.len(), 2);
+    }
+
+    #[test]
+    fn test_make_nullable_array_type() {
+        let mut prop = json!({"type": ["string", "integer"]});
+        make_nullable(&mut prop);
+        let types = prop["type"].as_array().unwrap();
+        assert_eq!(types.len(), 3);
+        assert!(types.contains(&json!("null")));
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -233,6 +233,8 @@ pub struct StreamUsage {
     pub completion_tokens: usize,
     /// Tokens served from cache, if the provider reports them.
     pub cache_hit_tokens: Option<usize>,
+    /// Tokens written to cache (cache creation), if the provider reports them.
+    pub cache_write_tokens: Option<usize>,
     /// Reasoning/thinking tokens, if the provider reports them.
     pub thinking_tokens: Option<usize>,
 }
@@ -243,12 +245,18 @@ impl StreamUsage {
             prompt_tokens,
             completion_tokens,
             cache_hit_tokens: None,
+            cache_write_tokens: None,
             thinking_tokens: None,
         }
     }
 
     pub fn with_cache_hit_tokens(mut self, tokens: usize) -> Self {
         self.cache_hit_tokens = Some(tokens);
+        self
+    }
+
+    pub fn with_cache_write_tokens(mut self, tokens: usize) -> Self {
+        self.cache_write_tokens = Some(tokens);
         self
     }
 
@@ -346,6 +354,15 @@ pub struct LLMResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_hit_tokens: Option<usize>,
 
+    /// Number of tokens written to cache (if provider supports caching).
+    ///
+    /// Anthropic: populated from `cache_creation_input_tokens` in usage.
+    /// These tokens are billed at a higher rate (1.25×) but are cheaper
+    /// on subsequent reads.  Tracking them separately enables accurate
+    /// cost accounting and audit of cache effectiveness.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_write_tokens: Option<usize>,
+
     /// Number of reasoning/thinking tokens used by the model.
     ///
     /// OODA-15: Extended thinking/reasoning mode capture
@@ -385,6 +402,7 @@ impl LLMResponse {
             tool_calls: Vec::new(),
             metadata: HashMap::new(),
             cache_hit_tokens: None,
+            cache_write_tokens: None,
             thinking_tokens: None,
             thinking_content: None,
         }
@@ -423,6 +441,17 @@ impl LLMResponse {
     /// - Append-only history patterns
     pub fn with_cache_hit_tokens(mut self, tokens: usize) -> Self {
         self.cache_hit_tokens = Some(tokens);
+        self
+    }
+
+    /// Set the number of tokens written to the provider's prompt cache.
+    ///
+    /// # Context Engineering Note
+    /// Cache write tokens are billed at 1.25× the normal input rate by Anthropic
+    /// but amortize quickly when the same prefix is reused across turns.
+    /// Tracking them separately enables accurate cost accounting.
+    pub fn with_cache_write_tokens(mut self, tokens: usize) -> Self {
+        self.cache_write_tokens = Some(tokens);
         self
     }
 

--- a/tests/e2e_anthropic.rs
+++ b/tests/e2e_anthropic.rs
@@ -694,16 +694,14 @@ async fn test_anthropic_compatible_auth_token_fallback_e2e() {
 
     std::env::set_var("ANTHROPIC_API_KEY", "");
 
-    let model = std::env::var("ANTHROPIC_MODEL")
-        .unwrap_or_else(|_| "claude-haiku-4.5".to_string());
+    let model = std::env::var("ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-haiku-4.5".to_string());
 
-    let provider = edgequake_llm::ProviderFactory::create_llm_provider("anthropic", &model)
-        .expect("explicit Anthropic provider creation should honor auth-token fallback and custom base URL");
+    let provider = edgequake_llm::ProviderFactory::create_llm_provider("anthropic", &model).expect(
+        "explicit Anthropic provider creation should honor auth-token fallback and custom base URL",
+    );
     let resp = provider
         .chat(
-            &[ChatMessage::user(
-                "Reply with exactly OK and nothing else.",
-            )],
+            &[ChatMessage::user("Reply with exactly OK and nothing else.")],
             None,
         )
         .await

--- a/tests/e2e_anthropic.rs
+++ b/tests/e2e_anthropic.rs
@@ -697,10 +697,9 @@ async fn test_anthropic_compatible_auth_token_fallback_e2e() {
     let model = std::env::var("ANTHROPIC_MODEL")
         .unwrap_or_else(|_| "claude-haiku-4.5".to_string());
 
-    let provider = AnthropicProvider::from_env()
-        .expect("auth token fallback should construct provider for Anthropic-compatible E2E");
+    let provider = edgequake_llm::ProviderFactory::create_llm_provider("anthropic", &model)
+        .expect("explicit Anthropic provider creation should honor auth-token fallback and custom base URL");
     let resp = provider
-        .with_model(&model)
         .chat(
             &[ChatMessage::user(
                 "Reply with exactly OK and nothing else.",

--- a/tests/e2e_anthropic.rs
+++ b/tests/e2e_anthropic.rs
@@ -672,6 +672,63 @@ async fn test_live_anthropic_invalid_key_returns_auth_error() {
 // ============================================================================
 
 #[tokio::test]
+#[ignore = "anthropic_live: requires ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN for Anthropic-compatible E2E"]
+async fn test_anthropic_compatible_auth_token_fallback_e2e() {
+    let old_api_key = std::env::var("ANTHROPIC_API_KEY").ok();
+    let old_auth_token = std::env::var("ANTHROPIC_AUTH_TOKEN").ok();
+    let old_base_url = std::env::var("ANTHROPIC_BASE_URL").ok();
+
+    let auth_token = std::env::var("ANTHROPIC_AUTH_TOKEN")
+        .expect("Set ANTHROPIC_AUTH_TOKEN for Anthropic-compatible E2E");
+    let base_url = std::env::var("ANTHROPIC_BASE_URL")
+        .expect("Set ANTHROPIC_BASE_URL for Anthropic-compatible E2E");
+
+    assert!(
+        !auth_token.trim().is_empty(),
+        "ANTHROPIC_AUTH_TOKEN must not be blank"
+    );
+    assert!(
+        !base_url.trim().is_empty(),
+        "ANTHROPIC_BASE_URL must not be blank"
+    );
+
+    std::env::set_var("ANTHROPIC_API_KEY", "");
+
+    let model = std::env::var("ANTHROPIC_MODEL")
+        .unwrap_or_else(|_| "claude-haiku-4.5".to_string());
+
+    let provider = AnthropicProvider::from_env()
+        .expect("auth token fallback should construct provider for Anthropic-compatible E2E");
+    let resp = provider
+        .with_model(&model)
+        .chat(
+            &[ChatMessage::user(
+                "Reply with exactly OK and nothing else.",
+            )],
+            None,
+        )
+        .await
+        .expect("Anthropic-compatible E2E request should succeed");
+
+    println!("[anthropic_compatible_e2e] content={:?}", resp.content);
+    assert!(!resp.content.trim().is_empty());
+    assert!(resp.content.to_ascii_uppercase().contains("OK"));
+
+    match old_api_key {
+        Some(v) => std::env::set_var("ANTHROPIC_API_KEY", v),
+        None => std::env::remove_var("ANTHROPIC_API_KEY"),
+    }
+    match old_auth_token {
+        Some(v) => std::env::set_var("ANTHROPIC_AUTH_TOKEN", v),
+        None => std::env::remove_var("ANTHROPIC_AUTH_TOKEN"),
+    }
+    match old_base_url {
+        Some(v) => std::env::set_var("ANTHROPIC_BASE_URL", v),
+        None => std::env::remove_var("ANTHROPIC_BASE_URL"),
+    }
+}
+
+#[tokio::test]
 #[ignore = "anthropic_live: requires ANTHROPIC_API_KEY env var"]
 async fn test_anthropic_live_basic_chat() {
     let provider = AnthropicProvider::from_env().expect("Set ANTHROPIC_API_KEY");


### PR DESCRIPTION
## Summary

Release `edgequake-llm` `0.6.12` with the unpublished provider compatibility work already staged locally.

## What changed

- add shared schema normalization utilities for provider adapters
- disable Anthropic strict mode when aggregate strict-tool budget limits are exceeded
- preserve final unterminated Anthropic-compatible SSE frames so streamed tool JSON is not truncated
- normalize Bedrock and Gemini tool schemas to the provider-specific JSON Schema subsets they accept
- expose cache-write token accounting on normalized response types
- refresh the crate README and changelog for the `0.6.12` release

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo publish --dry-run --locked`