### PR TITLE
fix(mistral): set max_batch_size() to 512 to prevent HTTP 400 error code 3210

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.15] - 2026-05-05
+
+### Fixed
+
+- **Mistral embedding provider now correctly reports `max_batch_size()` as 512.** The Mistral embeddings API enforces a hard limit of 512 inputs per request (HTTP 400, error code 3210: "Too many inputs in request"). Previously, `MistralProvider::max_batch_size()` fell through to the trait default of 2048, causing large documents (e.g. multi-hundred-chunk PDFs) to fail permanently with this error. A new constant `MISTRAL_EMBED_MAX_BATCH_SIZE = 512` is introduced and returned from `max_batch_size()`. The operator can further reduce this limit via the `EDGEQUAKE_EMBEDDING_BATCH_SIZE` env var, but the Mistral hard limit of 512 is always enforced as the ceiling.
+
 ## [0.6.14] - 2026-04-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "edgequake-llm"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"

--- a/src/providers/mistral.rs
+++ b/src/providers/mistral.rs
@@ -129,6 +129,14 @@ const MISTRAL_EMBED_DIMENSION: usize = 1024;
 /// Maximum tokens for `mistral-embed`
 const MISTRAL_EMBED_MAX_TOKENS: usize = 8192;
 
+/// Maximum number of input strings per `mistral-embed` API request.
+///
+/// Mistral's embedding endpoint enforces a hard limit of 512 inputs per request,
+/// independent of total token count. Exceeding this returns HTTP 400 error code
+/// 3210: "Too many inputs in request, split into more batches."
+/// Source: empirical validation against the Mistral API (error code 3210).
+const MISTRAL_EMBED_MAX_BATCH_SIZE: usize = 512;
+
 /// Provider display name
 const MISTRAL_PROVIDER_NAME: &str = "mistral";
 
@@ -1492,6 +1500,20 @@ impl EmbeddingProvider for MistralProvider {
         MISTRAL_EMBED_MAX_TOKENS
     }
 
+    /// Maximum number of inputs per embedding request.
+    ///
+    /// Mistral's API enforces a hard limit of 512 inputs per request (error code
+    /// 3210). Overriding the trait default (2048) ensures `embed_batched` splits
+    /// large input sets into compliant sub-batches before sending to the API.
+    fn max_batch_size(&self) -> usize {
+        // Allow operator override via env var, but cap at the Mistral hard limit.
+        let env_val = std::env::var("EDGEQUAKE_EMBEDDING_BATCH_SIZE")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(MISTRAL_EMBED_MAX_BATCH_SIZE);
+        env_val.min(MISTRAL_EMBED_MAX_BATCH_SIZE)
+    }
+
     /// Embed a batch of texts using `POST /v1/embeddings`.
     ///
     /// The returned vectors are in the same order as the input slice.
@@ -1816,6 +1838,11 @@ mod tests {
         .unwrap();
         assert_eq!(EmbeddingProvider::dimension(&p), MISTRAL_EMBED_DIMENSION);
         assert_eq!(EmbeddingProvider::max_tokens(&p), MISTRAL_EMBED_MAX_TOKENS);
+        assert_eq!(
+            EmbeddingProvider::max_batch_size(&p),
+            MISTRAL_EMBED_MAX_BATCH_SIZE,
+            "max_batch_size must report Mistral's hard input limit of 512 to prevent HTTP 400 error code 3210"
+        );
         assert_eq!(EmbeddingProvider::name(&p), "mistral");
         assert_eq!(EmbeddingProvider::model(&p), "mistral-embed");
         std::env::remove_var("MISTRAL_API_KEY");


### PR DESCRIPTION
## Problem

Mistral's embedding API enforces a hard limit of **512 inputs per request**. When exceeded it returns:
```
HTTP 400 – error code 3210 – "Too many inputs in request, split into more batches."
```

Previously `MistralProvider` had no `max_batch_size()` override and fell through to the `EmbeddingProvider` trait default of **2048**. This caused large document ingestions (e.g. multi-hundred-chunk PDFs) to fail permanently with this error.

## Fix

- Add `MISTRAL_EMBED_MAX_BATCH_SIZE = 512` constant with source documentation
- Override `max_batch_size()` in `MistralProvider` to return 512 (hard ceiling)
- Respect optional `EDGEQUAKE_EMBEDDING_BATCH_SIZE` env var for operator-level reduction (still capped at 512)
- Add assertion to `test_embedding_dimension` surface test to guard against regression
- Bump version to **0.6.15**

## Testing

```
cargo test -p edgequake-llm --lib -- providers::mistral
# result: 38 passed; 0 failed
```