### PR TITLE
feat(providers): add with_extra_headers() for B2B header propagation + fix CI idempotency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,27 @@ jobs:
       - name: Build release crate artifact
         run: cargo package --locked
 
-      - name: Publish
+      # Check idempotency: skip publish if this version is already on crates.io.
+      # This prevents exit-101 failures when a developer publishes locally before
+      # the tag-triggered CI workflow runs.
+      # See: specs/edgequake-llm-update/CI_PUBLISH_IDEMPOTENCY.md
+      - name: Check if version already published
+        shell: bash
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -n1 | cut -d'"' -f2)
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+            "https://crates.io/api/v1/crates/edgequake-llm/${VERSION}" \
+            -H "User-Agent: edgequake-llm-ci/1.0" 2>/dev/null || echo "000")
+          if [ "$STATUS" = "200" ]; then
+            echo "ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
+            echo "✓ edgequake-llm@${VERSION} is already published on crates.io — publish step will be skipped."
+          else
+            echo "ALREADY_PUBLISHED=false" >> "$GITHUB_ENV"
+            echo "→ edgequake-llm@${VERSION} not yet published (HTTP ${STATUS}) — will publish now."
+          fi
+
+      - name: Publish to crates.io
+        if: env.ALREADY_PUBLISHED == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.16] - 2026-05-06
+
+### Added
+
+- **`with_extra_headers()` builder on `MistralProvider` and `OpenAICompatibleProvider` (closes [edgequake#132](https://github.com/raphaelmansuy/edgequake/issues/132)).** B2B multi-tenant deployments can now propagate custom HTTP headers (`x-request-id`, `x-tenant-id`, `x-correlation-id`, `traceparent`, HMAC tokens, …) from inbound API requests into all outgoing LLM provider calls. Reserved headers (`authorization`, `content-type`, `content-length`, `host`, `user-agent`) are silently skipped to prevent overriding provider authentication. The feature covers both chat and embedding request paths.
+
+### Fixed
+
+- **CI `publish.yml` is now idempotent.** A new `Check if version already published` step queries the crates.io JSON API before attempting `cargo publish`. If the version already exists (HTTP 200), the publish step is skipped (shown as grey/skipped in GitHub Actions). This prevents the recurring `exit code 101 — crate already exists` failure when a developer publishes manually before the tag-triggered CI workflow runs. See `specs/edgequake-llm-update/CI_PUBLISH_IDEMPOTENCY.md`.
+
 ## [0.6.15] - 2026-05-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "edgequake-llm"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"

--- a/src/providers/mistral.rs
+++ b/src/providers/mistral.rs
@@ -570,6 +570,9 @@ pub struct MistralProvider {
     api_key: String,
     /// Shared HTTP client for native requests (embeddings, model listing)
     client: Client,
+    /// Extra HTTP headers forwarded on every outgoing API request.
+    /// Reserved headers (authorization, content-type, …) are excluded.
+    extra_headers: std::collections::HashMap<String, String>,
 }
 
 impl MistralProvider {
@@ -684,6 +687,7 @@ impl MistralProvider {
             base_url,
             api_key,
             client,
+            extra_headers: std::collections::HashMap::new(),
         })
     }
 
@@ -701,6 +705,86 @@ impl MistralProvider {
     /// Return a new provider configured for a different embedding model.
     pub fn with_embedding_model(mut self, model: &str) -> Self {
         self.embedding_model = model.to_string();
+        self
+    }
+
+    /// Add extra HTTP headers to every request made by this provider.
+    ///
+    /// Useful for B2B multi-tenant scenarios where tracing headers
+    /// (`x-request-id`, `x-tenant-id`, `traceparent`, …) must be propagated
+    /// from the caller into downstream LLM API calls.
+    ///
+    /// Reserved headers (`authorization`, `content-type`, `content-length`,
+    /// `host`, `user-agent`) are silently skipped to prevent overriding
+    /// provider authentication or protocol-level fields.
+    ///
+    /// See: `specs/edgequake-llm-update/HEADER_PROPAGATION.md`
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use edgequake_llm::MistralProvider;
+    /// # fn example() -> anyhow::Result<()> {
+    /// let provider = MistralProvider::from_env()?
+    ///     .with_extra_headers([
+    ///         ("x-request-id".to_string(), "req-123".to_string()),
+    ///         ("x-tenant-id".to_string(), "tenant-abc".to_string()),
+    ///     ]);
+    /// # Ok(()) }
+    /// ```
+    pub fn with_extra_headers(
+        mut self,
+        headers: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        const RESERVED: &[&str] = &[
+            "authorization",
+            "content-type",
+            "content-length",
+            "host",
+            "user-agent",
+        ];
+
+        let filtered: std::collections::HashMap<String, String> = headers
+            .into_iter()
+            .filter(|(k, _)| !RESERVED.contains(&k.to_lowercase().as_str()))
+            .collect();
+
+        // Propagate to inner OpenAI-compatible provider (handles chat/tool calls).
+        self.inner = self
+            .inner
+            .with_extra_headers(filtered.clone());
+
+        // Rebuild the native reqwest client so all direct HTTP calls (embeddings,
+        // model listing, audio, OCR) also carry the extra headers.
+        let mut header_map = reqwest::header::HeaderMap::new();
+        for (k, v) in &filtered {
+            if let (Ok(name), Ok(val)) = (
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()),
+                reqwest::header::HeaderValue::from_str(v),
+            ) {
+                header_map.insert(name, val);
+            } else {
+                tracing::warn!(
+                    header_name = %k,
+                    "with_extra_headers: invalid header name/value, skipping"
+                );
+            }
+        }
+        match Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .default_headers(header_map)
+            .build()
+        {
+            Ok(new_client) => self.client = new_client,
+            Err(e) => {
+                tracing::warn!(
+                    "with_extra_headers: failed to rebuild HTTP client, headers not applied: {}",
+                    e
+                );
+            }
+        }
+
+        self.extra_headers = filtered;
         self
     }
 
@@ -2270,5 +2354,95 @@ mod tests {
         let err_both = rt.block_on(async { p.transcribe(&req_both).await.unwrap_err() });
         assert!(matches!(err_both, LlmError::InvalidRequest(_)));
         std::env::remove_var("MISTRAL_API_KEY");
+    }
+
+    // -----------------------------------------------------------------------
+    // Header propagation tests (issue #132)
+    // See: specs/edgequake-llm-update/HEADER_PROPAGATION.md
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_with_extra_headers_stores_non_reserved_headers() {
+        // Verifies that with_extra_headers() accepts valid custom headers.
+        let p = MistralProvider::new(
+            "sk-test".to_string(),
+            MISTRAL_DEFAULT_MODEL.to_string(),
+            MISTRAL_DEFAULT_EMBEDDING_MODEL.to_string(),
+            None,
+        )
+        .unwrap()
+        .with_extra_headers([
+            ("x-request-id".to_string(), "req-abc".to_string()),
+            ("x-tenant-id".to_string(), "tenant-xyz".to_string()),
+        ]);
+
+        assert_eq!(
+            p.extra_headers.get("x-request-id"),
+            Some(&"req-abc".to_string()),
+            "x-request-id must be stored in extra_headers"
+        );
+        assert_eq!(
+            p.extra_headers.get("x-tenant-id"),
+            Some(&"tenant-xyz".to_string()),
+            "x-tenant-id must be stored in extra_headers"
+        );
+    }
+
+    #[test]
+    fn test_with_extra_headers_silently_drops_reserved_headers() {
+        // Verifies that reserved headers cannot override provider auth.
+        // EC-HEADER-02 (security): authorization must not be overridden.
+        let p = MistralProvider::new(
+            "original-key".to_string(),
+            MISTRAL_DEFAULT_MODEL.to_string(),
+            MISTRAL_DEFAULT_EMBEDDING_MODEL.to_string(),
+            None,
+        )
+        .unwrap()
+        .with_extra_headers([
+            ("authorization".to_string(), "Bearer injected-key".to_string()),
+            ("content-type".to_string(), "text/plain".to_string()),
+            ("user-agent".to_string(), "attacker/1.0".to_string()),
+            ("x-safe-header".to_string(), "ok".to_string()),
+        ]);
+
+        // Reserved headers must not appear in extra_headers.
+        assert!(
+            !p.extra_headers.contains_key("authorization"),
+            "authorization must be dropped from extra_headers"
+        );
+        assert!(
+            !p.extra_headers.contains_key("content-type"),
+            "content-type must be dropped from extra_headers"
+        );
+        assert!(
+            !p.extra_headers.contains_key("user-agent"),
+            "user-agent must be dropped from extra_headers"
+        );
+
+        // Safe custom header must be stored.
+        assert_eq!(
+            p.extra_headers.get("x-safe-header"),
+            Some(&"ok".to_string()),
+            "non-reserved header must be preserved"
+        );
+    }
+
+    #[test]
+    fn test_with_extra_headers_empty_map_is_noop() {
+        // EC-HEADER-01: empty extra_headers is a no-op.
+        let p = MistralProvider::new(
+            "sk-test".to_string(),
+            MISTRAL_DEFAULT_MODEL.to_string(),
+            MISTRAL_DEFAULT_EMBEDDING_MODEL.to_string(),
+            None,
+        )
+        .unwrap()
+        .with_extra_headers(std::iter::empty::<(String, String)>());
+
+        assert!(
+            p.extra_headers.is_empty(),
+            "extra_headers must be empty after no-op with_extra_headers"
+        );
     }
 }

--- a/src/providers/openai_compatible.rs
+++ b/src/providers/openai_compatible.rs
@@ -755,6 +755,63 @@ impl OpenAICompatibleProvider {
         self
     }
 
+    /// Add extra HTTP headers to every request made by this provider.
+    ///
+    /// Useful for B2B multi-tenant scenarios where tracing headers
+    /// (`x-request-id`, `x-tenant-id`, `traceparent`, …) must be propagated
+    /// from the caller into downstream LLM API calls.
+    ///
+    /// Reserved headers (`authorization`, `content-type`, `content-length`,
+    /// `host`, `user-agent`) are silently skipped to prevent overriding
+    /// provider authentication or protocol-level fields.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use edgequake_llm::providers::openai_compatible::OpenAICompatibleProvider;
+    /// # use std::collections::HashMap;
+    /// # fn example() -> anyhow::Result<()> {
+    /// let provider = OpenAICompatibleProvider::from_config(todo!())?
+    ///     .with_extra_headers([
+    ///         ("x-request-id".to_string(), "req-123".to_string()),
+    ///         ("x-tenant-id".to_string(), "tenant-abc".to_string()),
+    ///     ]);
+    /// # Ok(()) }
+    /// ```
+    pub fn with_extra_headers(
+        mut self,
+        headers: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        const RESERVED: &[&str] = &[
+            "authorization",
+            "content-type",
+            "content-length",
+            "host",
+            "user-agent",
+        ];
+
+        for (k, v) in headers {
+            if RESERVED.contains(&k.to_lowercase().as_str()) {
+                continue;
+            }
+            self.config.headers.insert(k, v);
+        }
+
+        // Rebuild the HTTP client so the new headers become default headers.
+        match Self::build_client(&self.config) {
+            Ok(new_client) => self.client = new_client,
+            Err(e) => {
+                // Log and keep the existing client rather than panicking.
+                tracing::warn!(
+                    "with_extra_headers: failed to rebuild HTTP client, headers not applied: {}",
+                    e
+                );
+            }
+        }
+
+        self
+    }
+
     /// Get the current model card.
     pub fn model_card(&self) -> Option<&ModelCard> {
         self.model_card.as_ref()


### PR DESCRIPTION
## Summary

Implements [edgequake#132](https://github.com/raphaelmansuy/edgequake/issues/132) — B2B multi-tenant customers need custom HTTP headers (`x-request-id`, `x-tenant-id`, `x-correlation-id`, `traceparent`, HMAC tokens) forwarded from EdgeQuake API requests into downstream LLM provider calls.

## Changes

### New: `with_extra_headers()` builder

Both `MistralProvider` and `OpenAICompatibleProvider` gain a `with_extra_headers()` builder method:

```rust
let provider = MistralProvider::from_env()?
    .with_extra_headers([
        ("x-request-id".to_string(), "req-123".to_string()),
        ("x-tenant-id".to_string(), "tenant-abc".to_string()),
    ]);
```

The headers are applied to **every outgoing API request** (chat, embedding, model listing). Reserved headers (`authorization`, `content-type`, `content-length`, `host`, `user-agent`) are silently skipped to prevent overriding provider authentication.

### Fix: idempotent CI publish

`publish.yml` now checks crates.io before publishing. If the version already exists, the publish step is shown as **skipped** (grey) instead of failing with exit code 101. Prevents the recurring failure when a developer publishes manually before the tag-triggered workflow runs.

## Tests

- `test_with_extra_headers_stores_non_reserved_headers`
- `test_with_extra_headers_silently_drops_reserved_headers`  
- `test_with_extra_headers_empty_map_is_noop`

All 1236 unit tests pass (1 pre-existing env-sensitivity failure in `factory::tests::test_from_env_fallback_to_mock` unrelated to this PR).

## Docs

See `specs/edgequake-llm-update/HEADER_PROPAGATION.md` for design rationale, security considerations, and edge case registry.