### PR TITLE
fix: edgequake-llm v0.6.24 — Mistral tool_calls, Bedrock coalesce, Copilot picker guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.24] - 2026-06-13
+
+### Fixed
+
+- **OpenAI-compatible `convert_messages`** — preserve assistant `tool_calls` in history so Mistral and other compatible APIs accept subsequent tool-result messages (fixes orphan `tool_call_id` rejections).
+- **Bedrock tool results** — coalesce consecutive tool-result messages into a single user message (OpenAI-shaped one-message-per-tool history from EdgeCrab).
+- **VS Code Copilot resolve** — reject routing picker model ids (`*-picker`, `flash-picker`) at resolve time.
+
 ## [0.6.23] - 2026-05-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "edgequake-llm"
-version = "0.6.23"
+version = "0.6.24"
 edition = "2021"
 authors = ["EdgeQuake Contributors"]
 license = "Apache-2.0"

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1806,6 +1806,7 @@ mod tests {
         std::env::remove_var("LMSTUDIO_HOST");
         std::env::remove_var("LMSTUDIO_MODEL");
         std::env::remove_var("MISTRAL_API_KEY");
+        std::env::remove_var("NVIDIA_API_KEY");
 
         let (llm, _) = ProviderFactory::from_env().unwrap();
         assert_eq!(llm.name(), "mock");

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -901,24 +901,33 @@ impl BedrockProvider {
         Self::build_message(ConversationRole::Assistant, content_blocks)
     }
 
-    fn convert_tool_result_message(msg: &ChatMessage) -> Result<Message> {
-        let tool_call_id = msg.tool_call_id.as_deref().ok_or_else(|| {
-            LlmError::InvalidRequest(
-                "Tool and function messages for Bedrock require a tool_call_id".to_string(),
-            )
-        })?;
+    /// in a **single** user message. EdgeCrab emits one ChatMessage per tool (OpenAI
+    /// shape); coalesce consecutive tool-result messages here.
+    fn convert_tool_result_messages(msgs: &[ChatMessage]) -> Result<Message> {
+        if msgs.is_empty() {
+            return Err(LlmError::InvalidRequest(
+                "Bedrock tool result conversion requires at least one tool message".to_string(),
+            ));
+        }
 
-        let tool_result = aws_sdk_bedrockruntime::types::ToolResultBlock::builder()
-            .tool_use_id(tool_call_id)
-            .content(aws_sdk_bedrockruntime::types::ToolResultContentBlock::Text(
-                msg.content.clone(),
-            ))
-            .build()?;
+        let mut content_blocks = Vec::with_capacity(msgs.len());
+        for msg in msgs {
+            let tool_call_id = msg.tool_call_id.as_deref().ok_or_else(|| {
+                LlmError::InvalidRequest(
+                    "Tool and function messages for Bedrock require a tool_call_id".to_string(),
+                )
+            })?;
 
-        Self::build_message(
-            ConversationRole::User,
-            vec![ContentBlock::ToolResult(tool_result)],
-        )
+            let tool_result = aws_sdk_bedrockruntime::types::ToolResultBlock::builder()
+                .tool_use_id(tool_call_id)
+                .content(aws_sdk_bedrockruntime::types::ToolResultContentBlock::Text(
+                    msg.content.clone(),
+                ))
+                .build()?;
+            content_blocks.push(ContentBlock::ToolResult(tool_result));
+        }
+
+        Self::build_message(ConversationRole::User, content_blocks)
     }
 
     /// Convert edgequake ChatMessages into Bedrock Messages + optional system blocks.
@@ -945,19 +954,36 @@ impl BedrockProvider {
             }
         }
 
-        for msg in messages {
-            match msg.role {
+        let mut i = 0usize;
+        while i < messages.len() {
+            match messages[i].role {
                 ChatRole::System => {
-                    if !msg.content.is_empty() {
-                        system_blocks.push(SystemContentBlock::Text(msg.content.clone()));
+                    if !messages[i].content.is_empty() {
+                        system_blocks.push(SystemContentBlock::Text(messages[i].content.clone()));
                     }
+                    i += 1;
                 }
-                ChatRole::User => bedrock_messages.push(Self::convert_user_message(msg)?),
+                ChatRole::User => {
+                    bedrock_messages.push(Self::convert_user_message(&messages[i])?);
+                    i += 1;
+                }
                 ChatRole::Assistant => {
-                    bedrock_messages.push(Self::convert_assistant_message(msg, tool_name_aliases)?)
+                    bedrock_messages
+                        .push(Self::convert_assistant_message(&messages[i], tool_name_aliases)?);
+                    i += 1;
                 }
                 ChatRole::Tool | ChatRole::Function => {
-                    bedrock_messages.push(Self::convert_tool_result_message(msg)?);
+                    let start = i;
+                    while i < messages.len()
+                        && matches!(
+                            messages[i].role,
+                            ChatRole::Tool | ChatRole::Function
+                        )
+                    {
+                        i += 1;
+                    }
+                    let batch = &messages[start..i];
+                    bedrock_messages.push(Self::convert_tool_result_messages(batch)?);
                 }
             }
         }
@@ -1828,6 +1854,48 @@ mod tests {
         assert_eq!(system_blocks.len(), 0);
         assert_eq!(bedrock_msgs.len(), 1);
         // Tool results are sent as user messages in Bedrock
+    }
+
+    #[test]
+    fn test_convert_messages_coalesces_parallel_tool_results() {
+        use crate::traits::{FunctionCall, ToolCall};
+
+        let messages = vec![
+            ChatMessage::user("find things"),
+            ChatMessage::assistant_with_tools(
+                "",
+                vec![
+                    ToolCall {
+                        id: "tooluse_a".into(),
+                        call_type: "function".into(),
+                        function: FunctionCall {
+                            name: "memory".into(),
+                            arguments: "{}".into(),
+                        },
+                        thought_signature: None,
+                    },
+                    ToolCall {
+                        id: "tooluse_b".into(),
+                        call_type: "function".into(),
+                        function: FunctionCall {
+                            name: "grep".into(),
+                            arguments: r#"{"pattern":"Gateway"}"#.into(),
+                        },
+                        thought_signature: None,
+                    },
+                ],
+            ),
+            ChatMessage::tool_result("tooluse_a", "memory ok"),
+            ChatMessage::tool_result("tooluse_b", "grep ok"),
+        ];
+        let (bedrock_msgs, _) = BedrockProvider::convert_messages(&messages, None).unwrap();
+        assert_eq!(bedrock_msgs.len(), 3, "user + assistant + coalesced tool results");
+        assert_eq!(*bedrock_msgs[2].role(), ConversationRole::User);
+        assert_eq!(
+            bedrock_msgs[2].content().len(),
+            2,
+            "both toolResult blocks must share one user message"
+        );
     }
 
     #[test]

--- a/src/providers/openai_compatible.rs
+++ b/src/providers/openai_compatible.rs
@@ -630,7 +630,22 @@ impl OpenAICompatibleProvider {
                     // on tool-role messages to name the tool that produced the result).
                     name: msg.name.clone(),
                     tool_call_id: msg.tool_call_id.clone(),
-                    tool_calls: None,
+                    // Assistant history must retain tool_calls so subsequent tool
+                    // results reference valid ids (Mistral/OpenAI-compatible APIs reject
+                    // orphan tool_call_id values when tool_calls were stripped).
+                    tool_calls: msg.tool_calls.as_ref().map(|calls| {
+                        calls
+                            .iter()
+                            .map(|tc| ToolCallRequest {
+                                id: tc.id.clone(),
+                                call_type: "function".to_string(),
+                                function: FunctionCallRequest {
+                                    name: tc.function.name.clone(),
+                                    arguments: tc.function.arguments.clone(),
+                                },
+                            })
+                            .collect()
+                    }),
                 }
             })
             .collect()
@@ -1734,6 +1749,31 @@ mod tests {
         assert_eq!(converted[0].role, "system");
         assert_eq!(converted[1].role, "user");
         assert_eq!(converted[2].role, "assistant");
+    }
+
+    #[test]
+    fn test_convert_messages_propagates_assistant_tool_calls() {
+        let tc = ToolCall {
+            id: "call-abc".to_string(),
+            call_type: "function".to_string(),
+            function: FunctionCall {
+                name: "file_read".to_string(),
+                arguments: r#"{"path":"./demo/game000"}"#.to_string(),
+            },
+            thought_signature: None,
+        };
+        let assistant = ChatMessage::assistant_with_tools("", vec![tc]);
+        let tool = ChatMessage::tool_result("call-abc", "error: is a directory");
+        let converted = OpenAICompatibleProvider::convert_messages(&[assistant, tool]);
+
+        let tool_calls = converted[0]
+            .tool_calls
+            .as_ref()
+            .expect("assistant tool_calls must be preserved");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, "call-abc");
+        assert_eq!(tool_calls[0].function.name, "file_read");
+        assert_eq!(converted[1].tool_call_id.as_deref(), Some("call-abc"));
     }
 
     #[test]

--- a/src/providers/vscode/client.rs
+++ b/src/providers/vscode/client.rs
@@ -379,8 +379,15 @@ impl VsCodeCopilotClient {
 
     async fn resolve_model_target(&self, requested_model: &str) -> Result<ResolvedModelTarget> {
         if !Self::is_auto_model(requested_model) {
+            let normalized = Self::normalize_model_name(requested_model);
+            if normalized.ends_with("-picker") || normalized.contains("flash-picker") {
+                return Err(VsCodeError::InvalidRequest(format!(
+                    "model \"{normalized}\" is a routing picker model, not a direct chat model. Try copilot/auto or a chat-capable model."
+                )));
+            }
+
             return Ok(ResolvedModelTarget {
-                model: Self::normalize_model_name(requested_model),
+                model: normalized,
                 auto_session_token: None,
             });
         }


### PR DESCRIPTION
## Summary
- Preserve assistant `tool_calls` in OpenAI-compatible `convert_messages` so Mistral and similar APIs accept subsequent tool-result messages.
- Coalesce consecutive Bedrock tool-result messages into one user message (OpenAI one-message-per-tool history).
- Reject Copilot routing picker model ids (`*-picker`, `flash-picker`) at resolve time.
- Clear `NVIDIA_API_KEY` in factory mock fallback test to avoid env pollution.

## Test plan
- [x] `cargo test --lib` — 1242 passed
- [x] New unit test `test_convert_messages_propagates_assistant_tool_calls`

## Release
Merge then tag `v0.6.24` to trigger crates.io publish workflow.

Made with [Cursor](https://cursor.com)